### PR TITLE
[FIXED] Icon error - removed mipmap

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.App"
         tools:targetApi="35"

--- a/app/src/main/res/drawable/ic_launcher_background.png
+++ b/app/src/main/res/drawable/ic_launcher_background.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2566cd2206889123aada5915a9dd8244dd971cf1d4462c0bf5b645e826f6ef0d
-size 4223

--- a/app/src/main/res/drawable/ic_launcher_foreground.png
+++ b/app/src/main/res/drawable/ic_launcher_foreground.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:630d44df4a23ff92ba22ed722499e60d3784a74d662d285bed59af2c96fe6341
-size 19841

--- a/app/src/main/res/drawable/ic_launcher_monochrome.png
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:630d44df4a23ff92ba22ed722499e60d3784a74d662d285bed59af2c96fe6341
-size 19841

--- a/app/src/main/res/drawable/weather_alert_icon.xml
+++ b/app/src/main/res/drawable/weather_alert_icon.xml
@@ -1,0 +1,44 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#4382ff"
+        android:pathData="m14.967,15.304c3.2,0 6,-2.41 6,-5.5 0,-3.09 -2.6,-5.5 -5.8,-5.5 -3.2,0 -5.8,2.41 -5.8,5.5 -0.6,-1.45 -2.4,-2.51 -4.2,-2.51 -2.3,0 -4.2,1.74 -4.2,3.96 0,2.22 1.7,4.05 4,4.05" />
+
+    <path
+        android:fillColor="#8fe4ff"
+        android:fillType="evenOdd"
+        android:pathData="m9.428,14.51c-0.595,0 -1.062,0.3 -1.269,0.789 -0.215,0.509 -0.801,0.747 -1.31,0.532 -0.509,-0.215 -0.747,-0.801 -0.532,-1.31 0.554,-1.311 1.806,-2.011 3.111,-2.011 1.927,0 3.38,1.594 3.38,3.5 0,1.906 -1.453,3.5 -3.38,3.5h-7.62c-0.552,0 -1,-0.448 -1,-1 0,-0.552 0.448,-1 1,-1h7.62c0.733,0 1.38,-0.606 1.38,-1.5 0,-0.894 -0.647,-1.5 -1.38,-1.5z" />
+
+    <path
+        android:fillColor="#8fe4ff"
+        android:fillType="evenOdd"
+        android:pathData="m15.998,18.43c-0.538,0 -1.061,0.354 -1.287,0.829 -0.237,0.499 -0.834,0.711 -1.332,0.474 -0.499,-0.237 -0.711,-0.834 -0.474,-1.332 0.534,-1.125 1.731,-1.971 3.093,-1.971 1.927,0 3.38,1.594 3.38,3.5 0,1.906 -1.453,3.5 -3.38,3.5H5.378c-0.552,0 -1,-0.448 -1,-1 0,-0.552 0.448,-1 1,-1H15.998c0.733,0 1.38,-0.606 1.38,-1.5 0,-0.894 -0.647,-1.5 -1.38,-1.5z" />
+
+    <path
+        android:fillColor="#8fe4ff"
+        android:pathData="m18.146,10.914c2.761,0 5,-2.239 5,-5 0,-2.761 -2.239,-5 -5,-5 -2.761,0 -5,2.239 -5,5 0,2.761 2.239,5 5,5z"
+        android:strokeWidth="1"
+        android:strokeColor="#121e3d"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+
+    <path
+        android:fillColor="#00000000"
+        android:pathData="m18.146,2.914v3"
+        android:strokeWidth="1"
+        android:strokeColor="#121e3d"
+        android:strokeLineJoin="round" />
+
+    <path
+        android:fillColor="#00000000"
+        android:pathData="m18.146,7.914h0.01"
+        android:strokeWidth="1"
+        android:strokeColor="#121e3d"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+
+</vector>

--- a/app/src/main/res/mipmap-anydpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi/ic_launcher.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@drawable/ic_launcher_foreground" />
-    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
-</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@drawable/ic_launcher_foreground" />
-    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
-</adaptive-icon>

--- a/resources/weather-alert-icon-108.svg
+++ b/resources/weather-alert-icon-108.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="108"
+   height="108"
+   viewBox="0 0 108 108"
+   fill="none"
+   data-reactroot=""
+   version="1.1"
+   id="svg3"
+   sodipodi:docname="alert-large.svg"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   inkscape:export-filename="cloud-breeze---filled-(24x24)@3x.svg"
+   inkscape:export-xdpi="165.34286"
+   inkscape:export-ydpi="165.34286"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="namedview3"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="2.741988"
+     inkscape:cx="104.66858"
+     inkscape:cy="-8.0233758"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3" />
+  <path
+     fill="#4382ff"
+     d="m 65.467178,66.904968 c 12.8,0 24,-9.64 24,-22 0,-12.36 -10.4,-22 -23.2,-22 -12.8,0 -23.200002,9.64 -23.200002,22 -2.4,-5.8 -9.6,-10.04 -16.8,-10.04 -9.2,0 -16.7999999,6.96 -16.7999999,15.84 0,8.88 6.7999999,16.2 15.9999999,16.2"
+     undefined="1"
+     id="path1"
+     style="stroke-width:4" />
+  <path
+     fill="#8fe4ff"
+     d="m 43.31152,63.726684 c -2.3784,0 -4.24988,1.2016 -5.075,3.156 -0.85928,2.0352 -3.20572,2.9884 -5.24088,2.1288 -2.03516,-0.8592 -2.9884,-3.2056 -2.12912,-5.2408 2.21488,-5.2456 7.22348,-8.044 12.445,-8.044 7.709198,0 13.519998,6.3756 13.519998,14 0,7.6244 -5.8108,14 -13.519998,14 H 12.831519 c -2.20912,0 -3.9999998,-1.7908 -3.9999998,-4 0,-2.2092 1.7908798,-4 3.9999998,-4 H 43.31152 c 2.930798,0 5.519998,-2.4244 5.519998,-6 0,-3.5756 -2.5892,-6 -5.519998,-6 z"
+     clip-rule="evenodd"
+     fill-rule="evenodd"
+     undefined="1"
+     id="path2"
+     style="stroke-width:4" />
+  <path
+     fill="#8fe4ff"
+     d="m 69.59061,79.408856 c -2.1516,0 -4.2436,1.4144 -5.1468,3.3164 -0.948,1.9952 -3.334,2.8444 -5.3296,1.8968 -1.9952,-0.948 -2.8444,-3.334 -1.8968,-5.3296 2.1368,-4.498 6.9248,-7.8836 12.3732,-7.8836 7.7092,0 13.52,6.3756 13.52,14 0,7.6244 -5.8108,14 -13.52,14 H 27.110608 c -2.20912,0 -4,-1.7908 -4,-4 0,-2.2092 1.79088,-4 4,-4 H 69.59061 c 2.9308,0 5.52,-2.4244 5.52,-6 0,-3.5756 -2.5892,-6 -5.52,-6 z"
+     clip-rule="evenodd"
+     fill-rule="evenodd"
+     undefined="1"
+     id="path3"
+     style="stroke-width:4" />
+  <path
+     stroke-linejoin="round"
+     stroke-linecap="round"
+     stroke-miterlimit="10"
+     stroke-width="4"
+     stroke="#121e3d"
+     fill="#8fe4ff"
+     d="m 78.181086,49.34306 c 11.0456,0 20,-8.954323 20,-20.000003 0,-11.04568 -8.9544,-19.9999995 -20,-19.9999995 -11.0456,0 -20,8.9543195 -20,19.9999995 0,11.04568 8.9544,20.000003 20,20.000003 z"
+     id="path4" />
+  <path
+     stroke-linejoin="round"
+     stroke-miterlimit="10"
+     stroke-width="4"
+     stroke="#121e3d"
+     d="m 78.181086,17.343057 v 12"
+     id="path5" />
+  <path
+     stroke-linejoin="round"
+     stroke-linecap="round"
+     stroke-miterlimit="10"
+     stroke-width="4"
+     stroke="#121e3d"
+     d="m 78.181086,37.343057 h 0.04"
+     id="path6" />
+</svg>


### PR DESCRIPTION
This pull request includes several changes to the Android app's resources and manifest file. The most important changes are the removal of the round icon reference from the manifest, deletion of launcher icon files, and addition of a new weather alert icon.

Changes to the Android Manifest:

* Removed the reference to the round launcher icon in `AndroidManifest.xml`.

Changes to drawable resources:

* Deleted the `ic_launcher_background.png`, `ic_launcher_foreground.png`, and `ic_launcher_monochrome.png` files from the drawable resources. [[1]](diffhunk://#diff-b4ac63ee01f486e48b050ae671e60e96d61278f095b3a9fb310fb2d8d21ef963L1-L3) [[2]](diffhunk://#diff-566898027008b4911d3a47f606dbf535ec6aec3c2bcaf10c140c0f293bbd882eL1-L3) [[3]](diffhunk://#diff-566898027008b4911d3a47f606dbf535ec6aec3c2bcaf10c140c0f293bbd882eL1-L3)
* Added a new vector drawable for the weather alert icon in `weather_alert_icon.xml`.

Changes to mipmap resources:

* Deleted the `ic_launcher.xml` and `ic_launcher_round.xml` files from the mipmap resources. [[1]](diffhunk://#diff-f05cfa2926d9f8c7c248ae2a44aafe392ba87c37b99ea2f910c690e04a966297L1-L6) [[2]](diffhunk://#diff-f05cfa2926d9f8c7c248ae2a44aafe392ba87c37b99ea2f910c690e04a966297L1-L6)