### PR TITLE
Add alert settings screen

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/MainActivity.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/MainActivity.kt
@@ -16,7 +16,7 @@ import com.slack.circuit.foundation.NavigableCircuitContent
 import com.slack.circuit.foundation.rememberCircuitNavigator
 import com.slack.circuitx.gesturenavigation.GestureNavigationDecoration
 import com.squareup.anvil.annotations.ContributesMultibinding
-import dev.hossain.weatheralert.circuit.InboxScreen
+import dev.hossain.weatheralert.circuit.AlertSettingsScreen
 import dev.hossain.weatheralert.di.ActivityKey
 import dev.hossain.weatheralert.di.AppScope
 import dev.hossain.weatheralert.ui.theme.WeatherAlertAppTheme
@@ -37,7 +37,7 @@ class MainActivity
                 WeatherAlertAppTheme {
                     Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                         // See https://slackhq.github.io/circuit/navigation/
-                        val backStack = rememberSaveableBackStack(root = InboxScreen)
+                        val backStack = rememberSaveableBackStack(root = AlertSettingsScreen("root"))
                         val navigator = rememberCircuitNavigator(backStack)
 
                         // See https://slackhq.github.io/circuit/circuit-content/

--- a/app/src/main/java/dev/hossain/weatheralert/circuit/AlertSettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/circuit/AlertSettingsScreen.kt
@@ -33,6 +33,8 @@ import com.slack.circuit.runtime.screen.Screen
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import dev.hossain.weatheralert.data.DEFAULT_RAIN_THRESHOLD
+import dev.hossain.weatheralert.data.DEFAULT_SNOW_THRESHOLD
 import dev.hossain.weatheralert.data.PreferencesManager
 import dev.hossain.weatheralert.di.AppScope
 import kotlinx.parcelize.Parcelize
@@ -64,8 +66,8 @@ constructor(
     @Composable
     override fun present(): AlertSettingsScreen.State {
         // State variables to hold threshold values
-        val snowThreshold by preferencesManager.snowThreshold.collectAsState(initial = 5.0f)
-        val rainThreshold by preferencesManager.rainThreshold.collectAsState(initial = 2.0f)
+        val snowThreshold by preferencesManager.snowThreshold.collectAsState(initial = DEFAULT_SNOW_THRESHOLD)
+        val rainThreshold by preferencesManager.rainThreshold.collectAsState(initial = DEFAULT_RAIN_THRESHOLD)
 
         var updatedSnowThreshold by remember { mutableStateOf(snowThreshold) }
         var updatedRainThreshold by remember { mutableStateOf(rainThreshold) }
@@ -107,7 +109,7 @@ fun AlertSettingsScreen(state: AlertSettingsScreen.State, modifier: Modifier = M
             modifier = modifier
                 .fillMaxSize()
                 .padding(padding)
-                .padding(16.dp),
+                .padding(24.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp)
         ) {
             // Snow Threshold Slider

--- a/app/src/main/java/dev/hossain/weatheralert/circuit/AlertSettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/circuit/AlertSettingsScreen.kt
@@ -1,0 +1,128 @@
+package dev.hossain.weatheralert.circuit
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import dev.hossain.weatheralert.data.PreferencesManager
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(preferencesManager: PreferencesManager) {
+    val scope = rememberCoroutineScope()
+
+    // State variables to hold threshold values
+    val snowThreshold by preferencesManager.snowThreshold.collectAsState(initial = 5.0f)
+    val rainThreshold by preferencesManager.rainThreshold.collectAsState(initial = 10.0f)
+
+    var updatedSnowThreshold by remember { mutableStateOf(snowThreshold) }
+    var updatedRainThreshold by remember { mutableStateOf(rainThreshold) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Configure Alerts") })
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            // Snow Threshold Slider
+            Text(text = "Snowfall Threshold: ${"%.1f".format(updatedSnowThreshold)} cm")
+            Slider(
+                value = updatedSnowThreshold,
+                onValueChange = { updatedSnowThreshold = it },
+                valueRange = 0f..50f,
+                steps = 10
+            )
+
+            // Rain Threshold Slider
+            Text(text = "Rainfall Threshold: ${"%.1f".format(updatedRainThreshold)} mm")
+            Slider(
+                value = updatedRainThreshold,
+                onValueChange = { updatedRainThreshold = it },
+                valueRange = 0f..50f,
+                steps = 10
+            )
+
+            Button(
+                onClick = {
+                    scope.launch {
+                        preferencesManager.updateSnowThreshold(updatedSnowThreshold)
+                        preferencesManager.updateRainThreshold(updatedRainThreshold)
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Save Settings")
+            }
+        }
+    }
+}
+
+/**
+ * Interactive Alert Threshold Adjustments
+ *
+ *     Purpose: Allow users to adjust alert thresholds in a fun and intuitive way.
+ *     Implementation: Use a slider or a rotary dial for thresholds.
+ *         Add haptic feedback for user interaction.
+ *         Animate the slider's color based on the value range (e.g., blue for low, red for high).
+ */
+@Composable
+fun ThresholdSlider(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    label: String,
+    max: Float
+) {
+    val color by animateColorAsState(
+        if (value < max / 2) Color.Blue else Color.Red
+    )
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(text = "$label: ${value.toInt()} cm", color = color)
+        Slider(
+            value = value,
+            onValueChange = onValueChange,
+            valueRange = 0f..max,
+            colors = SliderDefaults.colors(
+                thumbColor = color,
+                activeTrackColor = color
+            )
+        )
+    }
+}
+
+
+
+@Preview(showBackground = true)
+@Composable
+fun SettingsScreenPreview() {
+    SettingsScreen(preferencesManager = PreferencesManager(context = LocalContext.current))
+}

--- a/app/src/main/java/dev/hossain/weatheralert/circuit/AlertSettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/circuit/AlertSettingsScreen.kt
@@ -50,67 +50,76 @@ data class AlertSettingsScreen(
     ) : CircuitUiState
 
     sealed class Event : CircuitUiEvent {
-        data class SnowThresholdChanged(val value: Float) : Event()
-        data class RainThresholdChanged(val value: Float) : Event()
+        data class SnowThresholdChanged(
+            val value: Float,
+        ) : Event()
+
+        data class RainThresholdChanged(
+            val value: Float,
+        ) : Event()
+
         data object SaveSettingsClicked : Event()
     }
 }
 
 class AlertSettingsPresenter
-@AssistedInject
-constructor(
-    @Assisted private val navigator: Navigator,
-    @Assisted private val screen: AlertSettingsScreen,
-    private val preferencesManager: PreferencesManager,
-) : Presenter<AlertSettingsScreen.State> {
-    @Composable
-    override fun present(): AlertSettingsScreen.State {
-        // State variables to hold threshold values
-        val snowThreshold by preferencesManager.snowThreshold.collectAsState(initial = DEFAULT_SNOW_THRESHOLD)
-        val rainThreshold by preferencesManager.rainThreshold.collectAsState(initial = DEFAULT_RAIN_THRESHOLD)
+    @AssistedInject
+    constructor(
+        @Assisted private val navigator: Navigator,
+        @Assisted private val screen: AlertSettingsScreen,
+        private val preferencesManager: PreferencesManager,
+    ) : Presenter<AlertSettingsScreen.State> {
+        @Composable
+        override fun present(): AlertSettingsScreen.State {
+            // State variables to hold threshold values
+            val snowThreshold by preferencesManager.snowThreshold.collectAsState(initial = DEFAULT_SNOW_THRESHOLD)
+            val rainThreshold by preferencesManager.rainThreshold.collectAsState(initial = DEFAULT_RAIN_THRESHOLD)
 
-        var updatedSnowThreshold by remember { mutableStateOf(snowThreshold) }
-        var updatedRainThreshold by remember { mutableStateOf(rainThreshold) }
+            var updatedSnowThreshold by remember { mutableStateOf(snowThreshold) }
+            var updatedRainThreshold by remember { mutableStateOf(rainThreshold) }
 
-        return AlertSettingsScreen.State(updatedSnowThreshold, updatedRainThreshold) { event ->
-            when (event) {
-                AlertSettingsScreen.Event.SaveSettingsClicked -> TODO()
-                is AlertSettingsScreen.Event.RainThresholdChanged -> {
-                    updatedRainThreshold = event.value
-                }
-                is AlertSettingsScreen.Event.SnowThresholdChanged -> {
-                    updatedSnowThreshold = event.value
+            return AlertSettingsScreen.State(updatedSnowThreshold, updatedRainThreshold) { event ->
+                when (event) {
+                    AlertSettingsScreen.Event.SaveSettingsClicked -> TODO()
+                    is AlertSettingsScreen.Event.RainThresholdChanged -> {
+                        updatedRainThreshold = event.value
+                    }
+                    is AlertSettingsScreen.Event.SnowThresholdChanged -> {
+                        updatedSnowThreshold = event.value
+                    }
                 }
             }
         }
-    }
 
-    @CircuitInject(AlertSettingsScreen::class, AppScope::class)
-    @AssistedFactory
-    fun interface Factory {
-        fun create(
-            navigator: Navigator,
-            screen: AlertSettingsScreen,
-        ): AlertSettingsPresenter
+        @CircuitInject(AlertSettingsScreen::class, AppScope::class)
+        @AssistedFactory
+        fun interface Factory {
+            fun create(
+                navigator: Navigator,
+                screen: AlertSettingsScreen,
+            ): AlertSettingsPresenter
+        }
     }
-}
-
 
 @OptIn(ExperimentalMaterial3Api::class)
 @CircuitInject(AlertSettingsScreen::class, AppScope::class)
 @Composable
-fun AlertSettingsScreen(state: AlertSettingsScreen.State, modifier: Modifier = Modifier) {
+fun AlertSettingsScreen(
+    state: AlertSettingsScreen.State,
+    modifier: Modifier = Modifier,
+) {
     Scaffold(
         topBar = {
             TopAppBar(title = { Text("Configure Alerts") })
-        }
+        },
     ) { padding ->
         Column(
-            modifier = modifier
-                .fillMaxSize()
-                .padding(padding)
-                .padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(24.dp)
+            modifier =
+                modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp),
         ) {
             // Snow Threshold Slider
             Text(text = "Snowfall Threshold: ${"%.1f".format(state.snowThreshold)} cm")
@@ -120,7 +129,7 @@ fun AlertSettingsScreen(state: AlertSettingsScreen.State, modifier: Modifier = M
                     state.eventSink(AlertSettingsScreen.Event.SnowThresholdChanged(it))
                 },
                 valueRange = 1f..20f,
-                steps = 20
+                steps = 20,
             )
 
             // Rain Threshold Slider
@@ -131,14 +140,14 @@ fun AlertSettingsScreen(state: AlertSettingsScreen.State, modifier: Modifier = M
                     state.eventSink(AlertSettingsScreen.Event.RainThresholdChanged(it))
                 },
                 valueRange = 1f..20f,
-                steps = 20
+                steps = 20,
             )
 
             Button(
                 onClick = {
                     state.eventSink(AlertSettingsScreen.Event.SaveSettingsClicked)
                 },
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 Text("Save Settings")
             }
@@ -159,10 +168,10 @@ fun ThresholdSlider(
     value: Float,
     onValueChange: (Float) -> Unit,
     label: String,
-    max: Float
+    max: Float,
 ) {
     val color by animateColorAsState(
-        if (value < max / 2) Color.Blue else Color.Red
+        if (value < max / 2) Color.Blue else Color.Red,
     )
 
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -171,20 +180,19 @@ fun ThresholdSlider(
             value = value,
             onValueChange = onValueChange,
             valueRange = 0f..max,
-            colors = SliderDefaults.colors(
-                thumbColor = color,
-                activeTrackColor = color
-            )
+            colors =
+                SliderDefaults.colors(
+                    thumbColor = color,
+                    activeTrackColor = color,
+                ),
         )
     }
 }
-
-
 
 @Preview(showBackground = true)
 @Composable
 fun SettingsScreenPreview() {
     AlertSettingsScreen(
-        AlertSettingsScreen.State(snowThreshold = 5.0f, rainThreshold = 10.0f) {}
+        AlertSettingsScreen.State(snowThreshold = 5.0f, rainThreshold = 10.0f) {},
     )
 }

--- a/app/src/main/java/dev/hossain/weatheralert/data/Models.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/data/Models.kt
@@ -3,6 +3,9 @@ package dev.hossain.weatheralert.data
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
+const val DEFAULT_SNOW_THRESHOLD = 5.0f // cm
+const val DEFAULT_RAIN_THRESHOLD = 10.0f // mm
+
 @JsonClass(generateAdapter = true)
 data class WeatherForecast(
     val daily: List<DailyForecast>,

--- a/app/src/main/java/dev/hossain/weatheralert/data/PreferencesManager.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/data/PreferencesManager.kt
@@ -7,30 +7,32 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
-class PreferencesManager @Inject constructor(
-    @ApplicationContext private val context: Context,
-) {
-    private val dataStore = context.dataStore
+class PreferencesManager
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+    ) {
+        private val dataStore = context.dataStore
 
-    val snowThreshold: Flow<Float> =
-        dataStore.data.map { prefs ->
-            prefs[UserPreferences.snowThreshold] ?: DEFAULT_SNOW_THRESHOLD
+        val snowThreshold: Flow<Float> =
+            dataStore.data.map { prefs ->
+                prefs[UserPreferences.snowThreshold] ?: DEFAULT_SNOW_THRESHOLD
+            }
+
+        val rainThreshold: Flow<Float> =
+            dataStore.data.map { prefs ->
+                prefs[UserPreferences.rainThreshold] ?: DEFAULT_RAIN_THRESHOLD
+            }
+
+        suspend fun updateSnowThreshold(value: Float) {
+            dataStore.edit { prefs ->
+                prefs[UserPreferences.snowThreshold] = value
+            }
         }
 
-    val rainThreshold: Flow<Float> =
-        dataStore.data.map { prefs ->
-            prefs[UserPreferences.rainThreshold] ?: DEFAULT_RAIN_THRESHOLD
-        }
-
-    suspend fun updateSnowThreshold(value: Float) {
-        dataStore.edit { prefs ->
-            prefs[UserPreferences.snowThreshold] = value
+        suspend fun updateRainThreshold(value: Float) {
+            dataStore.edit { prefs ->
+                prefs[UserPreferences.rainThreshold] = value
+            }
         }
     }
-
-    suspend fun updateRainThreshold(value: Float) {
-        dataStore.edit { prefs ->
-            prefs[UserPreferences.rainThreshold] = value
-        }
-    }
-}

--- a/app/src/main/java/dev/hossain/weatheralert/data/PreferencesManager.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/data/PreferencesManager.kt
@@ -2,11 +2,20 @@ package dev.hossain.weatheralert.data
 
 import android.content.Context
 import androidx.datastore.preferences.core.edit
+import dev.hossain.weatheralert.di.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import javax.inject.Inject
 
-class PreferencesManager(
-    private val context: Context,
+/*
+Problem:
+
+    You're using @ContributesBinding to bind PreferencesManager to PreferencesManager. This means you are telling Dagger/Anvil: "Whenever I need a PreferencesManager, use this PreferencesManager." This is redundant and incorrect.
+    @ContributesBinding is designed to bind an implementation to an interface (or a superclass, though less common).
+ */
+//@ContributesBinding(AppScope::class, boundType = PreferencesManager::class)
+class PreferencesManager @Inject constructor(
+    @ApplicationContext private val context: Context,
 ) {
     private val dataStore = context.dataStore
 

--- a/app/src/main/java/dev/hossain/weatheralert/data/PreferencesManager.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/data/PreferencesManager.kt
@@ -7,13 +7,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
-/*
-Problem:
-
-    You're using @ContributesBinding to bind PreferencesManager to PreferencesManager. This means you are telling Dagger/Anvil: "Whenever I need a PreferencesManager, use this PreferencesManager." This is redundant and incorrect.
-    @ContributesBinding is designed to bind an implementation to an interface (or a superclass, though less common).
- */
-//@ContributesBinding(AppScope::class, boundType = PreferencesManager::class)
 class PreferencesManager @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
@@ -21,12 +14,12 @@ class PreferencesManager @Inject constructor(
 
     val snowThreshold: Flow<Float> =
         dataStore.data.map { prefs ->
-            prefs[UserPreferences.snowThreshold] ?: 5.0f // Default: 5 cm
+            prefs[UserPreferences.snowThreshold] ?: DEFAULT_SNOW_THRESHOLD
         }
 
     val rainThreshold: Flow<Float> =
         dataStore.data.map { prefs ->
-            prefs[UserPreferences.rainThreshold] ?: 10.0f // Default: 10 mm
+            prefs[UserPreferences.rainThreshold] ?: DEFAULT_RAIN_THRESHOLD
         }
 
     suspend fun updateSnowThreshold(value: Float) {


### PR DESCRIPTION
This pull request introduces a new `AlertSettingsScreen` to the `WeatherAlert` app and updates the navigation to use this new screen. The changes include creating the new screen, updating the main activity to navigate to it, and adding default threshold values for snow and rain.

### New Alert Settings Screen:

* Created `AlertSettingsScreen` with UI components to adjust snow and rain thresholds.
* Added `AlertSettingsPresenter` to manage the state and handle events for the `AlertSettingsScreen`.

### Navigation Updates:

* Updated `MainActivity` to use `AlertSettingsScreen` as the root screen instead of `InboxScreen`. [[1]](diffhunk://#diff-0291a11f6833a291c9e4b06e8ed11290e1e59b78897beea5ef5df69cbca7596bL19-R19) [[2]](diffhunk://#diff-0291a11f6833a291c9e4b06e8ed11290e1e59b78897beea5ef5df69cbca7596bL40-R40)

### Default Threshold Values:

* Added constants `DEFAULT_SNOW_THRESHOLD` and `DEFAULT_RAIN_THRESHOLD` in `Models.kt` to define default values for snow and rain thresholds.
* Updated `PreferencesManager` to use the new default threshold values.