### PR TITLE
[ADDED] Remove item snippet from example - WIP

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/circuit/CurrentAlertScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/circuit/CurrentAlertScreen.kt
@@ -199,7 +199,15 @@ fun CurrentWeatherAlerts(
                             .fillMaxSize()
                             .padding(padding),
                 ) {
-                    AlertTileGrid(tiles = state.tiles) {}
+                    AlertTileGrid(
+                        tiles = state.tiles,
+                        onUndo = {
+                            Timber.d("Undo clicked for: ${it.category}")
+                        },
+                        onRemove = {
+                            Timber.d("Remove clicked for: ${it.category}")
+                        },
+                    )
                 }
             },
         )
@@ -210,6 +218,7 @@ fun CurrentWeatherAlerts(
 fun AlertTileGrid(
     tiles: List<AlertTileData>,
     onUndo: (AlertTileData) -> Unit,
+    onRemove: (AlertTileData) -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -219,7 +228,7 @@ fun AlertTileGrid(
             items = tiles,
             key = { _, item -> item.uuid },
         ) { _, alertTileData ->
-            AlertTileItem(alertTileData = alertTileData, onRemove = onUndo)
+            AlertTileItem(alertTileData = alertTileData, onUndo = onUndo, onRemove = onRemove)
         }
     }
 }
@@ -228,6 +237,7 @@ fun AlertTileGrid(
 fun AlertTileItem(
     alertTileData: AlertTileData,
     modifier: Modifier = Modifier,
+    onUndo: (AlertTileData) -> Unit,
     onRemove: (AlertTileData) -> Unit,
 ) {
     val context = LocalContext.current

--- a/app/src/main/java/dev/hossain/weatheralert/circuit/CurrentAlertScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/circuit/CurrentAlertScreen.kt
@@ -1,23 +1,32 @@
 package dev.hossain.weatheralert.circuit
 
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.DismissDirection
+import androidx.compose.material.DismissValue
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.SwipeToDismiss
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.rememberDismissState
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -25,13 +34,17 @@ import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,6 +52,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.CircuitUiEvent
@@ -161,6 +175,9 @@ fun CurrentWeatherAlerts(
     modifier: Modifier = Modifier,
 ) {
     WeatherAlertAppTheme {
+        val scope = rememberCoroutineScope()
+        val snackbarHostState = remember { SnackbarHostState() }
+
         Scaffold(
             topBar = {
                 TopAppBar(title = { Text("Weather Alerts") })
@@ -174,6 +191,7 @@ fun CurrentWeatherAlerts(
                     icon = { Icon(Icons.Default.Add, contentDescription = "Add Alert") },
                 )
             },
+            snackbarHost = { SnackbarHost(snackbarHostState) },
             content = { padding ->
                 Column(
                     modifier =
@@ -181,22 +199,111 @@ fun CurrentWeatherAlerts(
                             .fillMaxSize()
                             .padding(padding),
                 ) {
-                    AlertTileGrid(tiles = state.tiles)
+                    AlertTileGrid(tiles = state.tiles) {}
                 }
             },
         )
     }
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun AlertTileGrid(tiles: List<AlertTileData>) {
-    LazyVerticalGrid(
-        columns = GridCells.Adaptive(minSize = 150.dp),
-        contentPadding = PaddingValues(8.dp),
-        modifier = Modifier.fillMaxSize(),
-    ) {
-        items(tiles) { tile ->
-            AlertTile(data = tile, modifier = Modifier.fillMaxWidth())
+fun AlertTileGrid(
+    tiles: List<AlertTileData>,
+    onUndo: (AlertTileData) -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val tilesState = remember { mutableStateListOf(*tiles.toTypedArray()) }
+
+// This is an example of a list of dismissible items, similar to what you would see in an
+// email app. Swiping left reveals a 'delete' icon and swiping right reveals a 'done' icon.
+// The background will start as grey, but once the dismiss threshold is reached, the colour
+// will animate to red if you're swiping left or green if you're swiping right. When you let
+// go, the item will animate out of the way if you're swiping left (like deleting an email) or
+// back to its default position if you're swiping right (like marking an email as read/unread).
+    LazyColumn {
+        items(
+            count = tiles.size,
+            key = { index -> tiles[index] },
+        ) { item: Int ->
+            var unread by remember { mutableStateOf(false) }
+            val dismissState =
+                rememberDismissState(
+                    confirmStateChange = {
+                        if (it == DismissValue.DismissedToEnd) unread = !unread
+                        it != DismissValue.DismissedToEnd
+                    },
+                )
+//            val dismissState = rememberDismissState(
+//                confirmStateChange = {
+//                    if (it == DismissValue.DismissedToEnd || it == DismissValue.DismissedToStart) {
+//                        tilesState.remove(tiles[item])
+//                        scope.launch {
+//                            val result = snackbarHostState.showSnackbar(
+//                                message = "Item deleted",
+//                                actionLabel = "Undo"
+//                            )
+//                            if (result == SnackbarResult.ActionPerformed) {
+//                                tilesState.add(tiles[item])
+//                                onUndo(tiles[item])
+//                            }
+//                        }
+//                    }
+//                    true
+//                }
+//            )
+            SwipeToDismiss(
+                state = dismissState,
+                modifier = Modifier.padding(vertical = 4.dp),
+                directions = setOf(DismissDirection.StartToEnd, DismissDirection.EndToStart),
+                background = {
+                    val direction = dismissState.dismissDirection ?: return@SwipeToDismiss
+                    val color by
+                        animateColorAsState(
+                            when (dismissState.targetValue) {
+                                DismissValue.Default -> Color.LightGray
+                                DismissValue.DismissedToEnd -> Color.Green
+                                DismissValue.DismissedToStart -> Color.Red
+                            },
+                            label = "background-color",
+                        )
+                    val alignment =
+                        when (direction) {
+                            DismissDirection.StartToEnd -> Alignment.CenterStart
+                            DismissDirection.EndToStart -> Alignment.CenterEnd
+                        }
+                    val icon =
+                        when (direction) {
+                            DismissDirection.StartToEnd -> Icons.Default.Done
+                            DismissDirection.EndToStart -> Icons.Default.Delete
+                        }
+                    val scale by
+                        animateFloatAsState(
+                            if (dismissState.targetValue == DismissValue.Default) 0.75f else 1f,
+                            label = "icon-scale",
+                        )
+
+                    Box(
+                        Modifier.fillMaxSize().background(color).padding(horizontal = 20.dp),
+                        contentAlignment = alignment,
+                    ) {
+                        Icon(
+                            icon,
+                            contentDescription = "Localized description",
+                            modifier = Modifier.scale(scale),
+                        )
+                    }
+                },
+                dismissContent = {
+                    val cardElevation: Dp =
+                        animateDpAsState(
+                            if (dismissState.dismissDirection != null) 8.dp else 4.dp,
+                            label = "card-elevation",
+                        ).value
+                    AlertTile(data = tiles[item], cardElevation, modifier = Modifier.fillMaxWidth())
+                },
+            )
         }
     }
 }
@@ -204,12 +311,13 @@ fun AlertTileGrid(tiles: List<AlertTileData>) {
 @Composable
 fun AlertTile(
     data: AlertTileData,
+    cardElevation: Dp,
     modifier: Modifier = Modifier,
 ) {
     Card(
         modifier = modifier.padding(8.dp),
         shape = RoundedCornerShape(12.dp),
-        elevation = CardDefaults.cardElevation(4.dp),
+        elevation = CardDefaults.cardElevation(cardElevation),
     ) {
         Column(
             modifier =

--- a/app/src/main/java/dev/hossain/weatheralert/data/Models.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/data/Models.kt
@@ -1,7 +1,9 @@
 package dev.hossain.weatheralert.data
 
+import android.os.Parcelable
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import kotlinx.parcelize.Parcelize
 
 const val DEFAULT_SNOW_THRESHOLD = 5.0f // cm
 const val DEFAULT_RAIN_THRESHOLD = 10.0f // mm
@@ -32,6 +34,7 @@ data class WeatherDescription(
     val icon: String,
 )
 
+@Parcelize
 data class AlertTileData constructor(
     /**
      * e.g., "Snowfall", "Rainfall"
@@ -45,7 +48,11 @@ data class AlertTileData constructor(
      * e.g., "Tomorrow: 7 cm", "Tomorrow: 15 mm"
      */
     val currentStatus: String,
-)
+    val uuid: String =
+        java.util.UUID
+            .randomUUID()
+            .toString(),
+) : Parcelable
 
 enum class WeatherAlertCategory(
     val label: String,


### PR DESCRIPTION
This pull request includes significant updates to the `CurrentAlertScreen` and `Models` files to enhance the user interface and data handling for weather alerts. The most important changes include switching from a grid to a column layout for alert tiles, adding swipe-to-dismiss functionality, and making `AlertTileData` implement the `Parcelable` interface.

### UI Enhancements:

* [`CurrentAlertScreen.kt`](diffhunk://#diff-285a2d740453a4e41c6c5a355d49a43dc7d4084a2457b5ea1c85588b24be74a3R3-R55): Changed `AlertTileGrid` from a grid layout (`LazyVerticalGrid`) to a column layout (`LazyColumn`) and added swipe-to-dismiss functionality to alert tiles. [[1]](diffhunk://#diff-285a2d740453a4e41c6c5a355d49a43dc7d4084a2457b5ea1c85588b24be74a3R3-R55) [[2]](diffhunk://#diff-285a2d740453a4e41c6c5a355d49a43dc7d4084a2457b5ea1c85588b24be74a3R178-R180) [[3]](diffhunk://#diff-285a2d740453a4e41c6c5a355d49a43dc7d4084a2457b5ea1c85588b24be74a3R194-R318)

### Data Handling:

* [`Models.kt`](diffhunk://#diff-b660e9e33578ce26b64a16c0ae38d8ea9ea4e124a3f6ee7075ca6fb0a377cc69R3-R6): Updated `AlertTileData` to implement the `Parcelable` interface and added a `uuid` property for uniquely identifying alert tiles. [[1]](diffhunk://#diff-b660e9e33578ce26b64a16c0ae38d8ea9ea4e124a3f6ee7075ca6fb0a377cc69R3-R6) [[2]](diffhunk://#diff-b660e9e33578ce26b64a16c0ae38d8ea9ea4e124a3f6ee7075ca6fb0a377cc69R37) [[3]](diffhunk://#diff-b660e9e33578ce26b64a16c0ae38d8ea9ea4e124a3f6ee7075ca6fb0a377cc69L48-R55)