### PR TITLE
[FIXED] Alert settings and removal logic

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/circuit/AlertSettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/circuit/AlertSettingsScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -94,14 +93,6 @@ class AlertSettingsPresenter
             val scope = rememberCoroutineScope()
             var updatedSnowThreshold by remember { mutableFloatStateOf(0f) }
             var updatedRainThreshold by remember { mutableFloatStateOf(0f) }
-
-            LaunchedEffect(Unit) {
-                updatedSnowThreshold = preferencesManager.currentSnowThreshold()
-                updatedRainThreshold = preferencesManager.currentRainThreshold()
-
-                preferencesManager.snowThreshold.collect { updatedSnowThreshold = it }
-                preferencesManager.rainThreshold.collect { updatedRainThreshold = it }
-            }
 
             return AlertSettingsScreen.State(updatedSnowThreshold, updatedRainThreshold) { event ->
                 when (event) {
@@ -221,7 +212,6 @@ fun AlertSettingsScreen(
                                         state.eventSink(AlertSettingsScreen.Event.SnowThresholdChanged(it))
                                     },
                                     valueRange = 1f..20f,
-                                    steps = 20,
                                 )
                             }
                         1 ->
@@ -238,7 +228,6 @@ fun AlertSettingsScreen(
                                         state.eventSink(AlertSettingsScreen.Event.RainThresholdChanged(it))
                                     },
                                     valueRange = 1f..20f,
-                                    steps = 20,
                                 )
                             }
                     }


### PR DESCRIPTION
This pull request includes changes to the `AlertSettingsScreen` and `CurrentAlertScreen` components to improve functionality and simplify the codebase. The most important changes include removing unused imports, refactoring state management, and updating event handling for alert removal.

Improvements to `AlertSettingsScreen`:

* Removed the unused `LaunchedEffect` import from `AlertSettingsScreen.kt`.
* Removed the `LaunchedEffect` block that initialized and collected threshold values from `preferencesManager`.
* Removed the `steps` parameter from the `Slider` components in the `AlertSettingsScreen` function. [[1]](diffhunk://#diff-a1eee5b2c17bf37e9972337dda872798d8c53fc6a759751a467d3e32abf2d240L224) [[2]](diffhunk://#diff-a1eee5b2c17bf37e9972337dda872798d8c53fc6a759751a467d3e32abf2d240L241)

Improvements to `CurrentAlertScreen`:

* Removed the unused `Archive` icon import from `CurrentAlertScreen.kt`.
* Added a new event `AlertRemoved` to handle alert removal.
* Updated `CurrentWeatherAlertPresenter` to handle the `AlertRemoved` event and remove alerts locally.
* Refactored `AlertTileGrid` and `AlertTileItem` to use an `eventSink` for event handling instead of individual callbacks. [[1]](diffhunk://#diff-285a2d740453a4e41c6c5a355d49a43dc7d4084a2457b5ea1c85588b24be74a3L220-R226) [[2]](diffhunk://#diff-285a2d740453a4e41c6c5a355d49a43dc7d4084a2457b5ea1c85588b24be74a3L231-R240) [[3]](diffhunk://#diff-285a2d740453a4e41c6c5a355d49a43dc7d4084a2457b5ea1c85588b24be74a3L240-L256)
* Changed the background color for dismiss actions to red and updated the icon for deletion. [[1]](diffhunk://#diff-285a2d740453a4e41c6c5a355d49a43dc7d4084a2457b5ea1c85588b24be74a3L283-R290) [[2]](diffhunk://#diff-285a2d740453a4e41c6c5a355d49a43dc7d4084a2457b5ea1c85588b24be74a3L303-R310)