### PR TITLE
[UPDATE] Get latest forcast for city all the time.

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/db/CityForecastDao.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/db/CityForecastDao.kt
@@ -24,6 +24,12 @@ interface CityForecastDao {
     @Query("SELECT * FROM city_forecasts WHERE forecast_id = :forecastId")
     suspend fun getCityForecastById(forecastId: Int): CityForecast?
 
-    @Query("SELECT * FROM city_forecasts WHERE cityId = :cityId")
+    /**
+     * Get latest forecast for a city.
+     *
+     * In future, we may have to cleanup the table to keep only latest forecast for each city.
+     * However, this is not required for now.
+     */
+    @Query("SELECT * FROM city_forecasts WHERE cityId = :cityId ORDER BY created_at DESC")
     suspend fun getCityForecastsByCityId(cityId: Int): List<CityForecast>
 }


### PR DESCRIPTION
This pull request includes a change to the `CityForecastDao` interface in the `CityForecastDao.kt` file to enhance the retrieval of city forecasts. The most important change is the modification of the `getCityForecastsByCityId` query to order the results by the creation date in descending order.

Enhancements to city forecast retrieval:

* [`app/src/main/java/dev/hossain/weatheralert/db/CityForecastDao.kt`](diffhunk://#diff-9fbcbca7ee15579ddb918f02db9f42ff3c24d30471b389fe72db50d0aae31d5dL27-R33): Modified the `getCityForecastsByCityId` query to order forecasts by `created_at` in descending order, ensuring the latest forecast is retrieved first. Added a comment explaining the potential future need to clean up the table to keep only the latest forecast for each city.