### PR TITLE
Tomorrow io error handling

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/ui/addalert/AddNewWeatherAlertScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/addalert/AddNewWeatherAlertScreen.kt
@@ -97,6 +97,7 @@ import dev.hossain.weatheralert.ui.serviceConfig
 import dev.hossain.weatheralert.ui.theme.WeatherAlertAppTheme
 import dev.hossain.weatheralert.ui.theme.dimensions
 import dev.hossain.weatheralert.util.Analytics
+import io.tomorrow.api.TomorrowIoService
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.openweathermap.api.OpenWeatherService
@@ -248,6 +249,22 @@ class AddWeatherAlertPresenter
                                     isSaveButtonEnabled = true
                                     when (dailyForecast.code) {
                                         OpenWeatherService.ERROR_HTTP_UNAUTHORIZED -> {
+                                            snackbarData =
+                                                SnackbarData(
+                                                    message =
+                                                        "The weather API is is likely exhausted or not active. " +
+                                                            "Please add your own API key.",
+                                                    actionLabel = "Add Key",
+                                                ) {
+                                                    navigator.goTo(
+                                                        BringYourOwnApiKeyScreen(
+                                                            weatherApiService = selectedApiService!!,
+                                                            isOriginatedFromError = true,
+                                                        ),
+                                                    )
+                                                }
+                                        }
+                                        TomorrowIoService.ERROR_HTTP_FORBIDDEN -> {
                                             snackbarData =
                                                 SnackbarData(
                                                     message =

--- a/service/tomorrowio/src/main/java/io/tomorrow/api/TomorrowIoService.kt
+++ b/service/tomorrowio/src/main/java/io/tomorrow/api/TomorrowIoService.kt
@@ -25,7 +25,7 @@ interface TomorrowIoService {
          * ------   -----------         ------------
          * 401001	Invalid Key	        The method requires authentication, but it was not presented or is invalid.
          */
-        private const val ERROR_HTTP_UNAUTHORIZED = 401
+        const val ERROR_HTTP_UNAUTHORIZED = 401
 
         /**
          * 402 PAYMENT REQUIRED:
@@ -33,7 +33,7 @@ interface TomorrowIoService {
          * ------   -----------         ------------
          * 402001	Insufficient Tokens	Adding additional tokens is required
          */
-        private const val ERROR_HTTP_PAYMENT_REQUIRED = 402
+        const val ERROR_HTTP_PAYMENT_REQUIRED = 402
 
         /**
          * 403 FORBIDDEN:
@@ -44,7 +44,16 @@ interface TomorrowIoService {
          * 403002	Account Limit	    The plan limit for a resource has been reached.
          * 403003	Forbidden Action	The plan is restricted and cannot perform this action.
          */
-        private const val ERROR_HTTP_FORBIDDEN = 403
+        const val ERROR_HTTP_FORBIDDEN = 403
+
+        /**
+         * 404 NOT FOUND:
+         *
+         * Code	    Type	            Description
+         * ------   -----------         ------------
+         * 404001	Not Found	        A resource id was not found.
+         */
+        const val ERROR_HTTP_NOT_FOUND = 404
     }
 
     /**

--- a/service/tomorrowio/src/main/java/io/tomorrow/api/TomorrowIoService.kt
+++ b/service/tomorrowio/src/main/java/io/tomorrow/api/TomorrowIoService.kt
@@ -18,6 +18,35 @@ import retrofit2.http.Query
  * - Requests per day: 500
  */
 interface TomorrowIoService {
+    companion object {
+        /**
+         * 401 UNAUTHORIZED:
+         * Code	    Type	            Description
+         * ------   -----------         ------------
+         * 401001	Invalid Key	        The method requires authentication, but it was not presented or is invalid.
+         */
+        private const val ERROR_HTTP_UNAUTHORIZED = 401
+
+        /**
+         * 402 PAYMENT REQUIRED:
+         * Code	    Type	            Description
+         * ------   -----------         ------------
+         * 402001	Insufficient Tokens	Adding additional tokens is required
+         */
+        private const val ERROR_HTTP_PAYMENT_REQUIRED = 402
+
+        /**
+         * 403 FORBIDDEN:
+         *
+         * Code	    Type	            Description
+         * ------   -----------         ------------
+         * 403001	Access Denied	    The authentication token in use is restricted and cannot access the requested resource.
+         * 403002	Account Limit	    The plan limit for a resource has been reached.
+         * 403003	Forbidden Action	The plan is restricted and cannot perform this action.
+         */
+        private const val ERROR_HTTP_FORBIDDEN = 403
+    }
+
     /**
      * Fetch weather forecast data based on location.
      *


### PR DESCRIPTION
This pull request includes changes to integrate the Tomorrow.io weather API service and handle its specific error codes in the `AddNewWeatherAlertScreen` component. The most important changes include importing the new service, handling a new error code, and defining error constants for the Tomorrow.io API.

Integration of Tomorrow.io service:

* [`app/src/main/java/dev/hossain/weatheralert/ui/addalert/AddNewWeatherAlertScreen.kt`](diffhunk://#diff-0cda03dd93f310418f322ace54d8695b5ca39959bb046709020731248bf66eeeR100): Added import for `TomorrowIoService` to integrate the new weather API service.

Error handling improvements:

* [`app/src/main/java/dev/hossain/weatheralert/ui/addalert/AddNewWeatherAlertScreen.kt`](diffhunk://#diff-0cda03dd93f310418f322ace54d8695b5ca39959bb046709020731248bf66eeeR267-R282): Added handling for `TomorrowIoService.ERROR_HTTP_FORBIDDEN` to display a snackbar message and navigate to the `BringYourOwnApiKeyScreen` when the API key is exhausted or not active.
* [`service/tomorrowio/src/main/java/io/tomorrow/api/TomorrowIoService.kt`](diffhunk://#diff-f432700aac2cee4f61dcdedc3c6d10987cd8763914877138be2f94ee035d3425R21-R58): Defined constants for various HTTP error codes (401, 402, 403, 404) to standardize error handling for the Tomorrow.io API.