### PR TITLE
[ADDED] City selection indicator for better UX

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/ui/addalert/AddNewWeatherAlertScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/addalert/AddNewWeatherAlertScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.LocationCity
 import androidx.compose.material3.Button
@@ -666,6 +667,7 @@ fun EditableCityInputDropdownMenu(
     onSuggestionClick: (City) -> Unit,
 ) {
     val textFieldState: TextFieldState = rememberTextFieldState()
+    var lastSelectedCity by remember { mutableStateOf<City?>(null) }
 
     // The text that the user inputs into the text field can be used to filter the options.
     // This sample uses string subsequence matching.
@@ -681,6 +683,7 @@ fun EditableCityInputDropdownMenu(
         OutlinedTextField(
             value = textFieldState.text.toString(),
             onValueChange = { newValue ->
+                lastSelectedCity = null
                 textFieldState.setTextAndPlaceCursorAtEnd(newValue)
                 onQueryChange(newValue)
                 setExpanded(newValue.isNotEmpty())
@@ -698,6 +701,22 @@ fun EditableCityInputDropdownMenu(
             // Commented because of grey tint color in the box
             // colors = ExposedDropdownMenuDefaults.textFieldColors(),
             leadingIcon = { Icon(Icons.Default.LocationCity, contentDescription = null) },
+            trailingIcon = {
+                lastSelectedCity?.let {
+                    Icon(
+                        imageVector = Icons.Default.Check,
+                        contentDescription = "Clear selected city",
+                        tint = MaterialTheme.colorScheme.secondary,
+                        modifier =
+                            Modifier.clickable {
+                                textFieldState.setTextAndPlaceCursorAtEnd("")
+                                onQueryChange("")
+                                setExpanded(false)
+                                lastSelectedCity = null
+                            },
+                    )
+                }
+            },
         )
         ExposedDropdownMenu(
             modifier = Modifier.heightIn(max = 280.dp),
@@ -715,6 +734,7 @@ fun EditableCityInputDropdownMenu(
                     onClick = {
                         textFieldState.setTextAndPlaceCursorAtEnd(city.cityName)
                         setExpanded(false)
+                        lastSelectedCity = city
                         onSuggestionClick(city)
                     },
                     contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,

--- a/app/src/main/res/drawable/search_check_checked.xml
+++ b/app/src/main/res/drawable/search_check_checked.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M400,640q100,0 170,-70t70,-170q0,-100 -70,-170t-170,-70q-100,0 -170,70t-70,170q0,100 70,170t170,70ZM358,428 L301,372q-12,-12 -28,-12t-28,12q-12,12 -12.5,28t11.5,28l85,85q12,12 28.5,12t28.5,-12l170,-169q12,-12 12,-28.5T556,287q-12,-12 -28.5,-12T499,287L358,428ZM400,720q-134,0 -227,-93T80,400q0,-134 93,-227t227,-93q134,0 227,93t93,227q0,56 -17.5,105.5T653,596l199,199q12,12 12,28.5T852,852q-12,12 -28.5,12T795,852L596,653q-41,32 -90.5,49.5T400,720ZM400,400Z"
+      android:fillColor="#e8eaed"/>
+</vector>


### PR DESCRIPTION
This pull request includes changes to the `AddNewWeatherAlertScreen` in order to add a new feature that allows users to clear their selected city. Additionally, a new drawable resource has been added.

### AddNewWeatherAlertScreen Improvements:

* Added `lastSelectedCity` state to keep track of the last selected city.
* Updated the `OutlinedTextField` to reset `lastSelectedCity` when the input value changes.
* Added a trailing icon to the `OutlinedTextField` that allows users to clear the selected city.
* Set `lastSelectedCity` when a city is selected from the dropdown menu.

### Resource Addition:

* Added a new vector drawable resource `search_check_checked.xml` for the clear selected city icon.