### PR TITLE
Fix add api key

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/ui/addalert/AddNewWeatherAlertScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/addalert/AddNewWeatherAlertScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType.Companion.PrimaryEditable
@@ -385,18 +386,15 @@ fun AddNewWeatherAlertScreen(
             TopAppBar(
                 title = { Text("Configure Alerts") },
                 navigationIcon = {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Go back",
-                        modifier = Modifier,
-                    )
+                    IconButton(onClick = {
+                        state.eventSink(AddNewWeatherAlertScreen.Event.GoBack)
+                    }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Go back",
+                        )
+                    }
                 },
-                modifier =
-                    Modifier
-                        .padding(start = 8.dp)
-                        .clickable {
-                            state.eventSink(AddNewWeatherAlertScreen.Event.GoBack)
-                        },
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },

--- a/app/src/main/java/dev/hossain/weatheralert/ui/addapikey/ByoApiKeyScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/addapikey/ByoApiKeyScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.LinkAnnotation
@@ -164,10 +165,6 @@ class BringYourOwnApiKeyPresenter
                         val isValidKey =
                             apiKeyProvider.isValidKey(screen.weatherApiService, event.value)
                         isApiKeyValid = isValidKey
-                        if (isValidKey) {
-                            // Update the label if it somehow is reset to build config key
-                            isUserProvidedApiKey = isUserProvidedApiKey(screen.weatherApiService, event.value)
-                        }
                     }
 
                     is BringYourOwnApiKeyScreen.Event.SubmitApiKey -> {
@@ -189,6 +186,9 @@ class BringYourOwnApiKeyPresenter
                                         }
                                 }
                                 is ApiResult.Failure -> {
+                                    // Reset the supporting text message to show the API format guide.
+                                    isUserProvidedApiKey = false
+
                                     var serverMessage = ""
                                     if (result is ApiResult.Failure.HttpFailure) {
                                         result.error?.let {
@@ -248,6 +248,7 @@ fun BringYourOwnApiKeyScreen(
 ) {
     val serviceConfig: WeatherServiceLogoConfig = state.weatherService.serviceConfig()
     val snackbarHostState = remember { SnackbarHostState() }
+    val keyboardController = LocalSoftwareKeyboardController.current
 
     Scaffold(
         topBar = {
@@ -324,7 +325,10 @@ fun BringYourOwnApiKeyScreen(
 
             Button(
                 enabled = state.isApiKeyValid,
-                onClick = { state.eventSink(BringYourOwnApiKeyScreen.Event.SubmitApiKey(state.apiKeyInput)) },
+                onClick = {
+                    keyboardController?.hide()
+                    state.eventSink(BringYourOwnApiKeyScreen.Event.SubmitApiKey(state.apiKeyInput))
+                },
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text("Save API Key")


### PR DESCRIPTION
This pull request includes several changes to the `AddNewWeatherAlertScreen` and `ByoApiKeyScreen` components in the `app/src/main/java/dev/hossain/weatheralert/ui` directory. The main changes involve adding new imports, modifying button behaviors, and updating the handling of API key validation.

Changes to `AddNewWeatherAlertScreen`:

* Added `IconButton` import and updated the navigation icon to use `IconButton` for handling the "Go back" action. [[1]](diffhunk://#diff-0cda03dd93f310418f322ace54d8695b5ca39959bb046709020731248bf66eeeR37) [[2]](diffhunk://#diff-0cda03dd93f310418f322ace54d8695b5ca39959bb046709020731248bf66eeeR389-R396)

Changes to `ByoApiKeyScreen`:

* Added `LocalSoftwareKeyboardController` import to manage the software keyboard.
* Removed redundant code for updating the user-provided API key label when the key is valid.
* Added a reset for the supporting text message to show the API format guide on API key validation failure.
* Integrated `keyboardController` to hide the keyboard when the "Save API Key" button is clicked. [[1]](diffhunk://#diff-7207571ba3b25ab6b4f6cdaf53cb82e4ce64354a605d5bb85ad6778646e79bfbR251) [[2]](diffhunk://#diff-7207571ba3b25ab6b4f6cdaf53cb82e4ce64354a605d5bb85ad6778646e79bfbL327-R331)