### PR TITLE
Expand analytics for worker and screens

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/ui/addapikey/ByoApiKeyScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/addapikey/ByoApiKeyScreen.kt
@@ -175,6 +175,7 @@ class BringYourOwnApiKeyPresenter
                             when (result) {
                                 is ApiResult.Success -> {
                                     Timber.d("API key is valid - saving to preferences.")
+                                    logAddServiceApiKey(isApiKeyAdded = true)
                                     preferencesManager.saveUserApiKey(screen.weatherApiService, apiKey)
                                     snackbarData =
                                         SnackbarData("✔️API key is valid and saved.", "Continue") {
@@ -186,6 +187,7 @@ class BringYourOwnApiKeyPresenter
                                         }
                                 }
                                 is ApiResult.Failure -> {
+                                    logAddServiceApiKey(isApiKeyAdded = false)
                                     // Reset the supporting text message to show the API format guide.
                                     isUserProvidedApiKey = false
 
@@ -228,6 +230,14 @@ class BringYourOwnApiKeyPresenter
                 WeatherService.TOMORROW_IO -> apiKey.isNotEmpty() && apiKey != BuildConfig.TOMORROW_IO_API_KEY
                 WeatherService.OPEN_METEO -> false
             }
+
+        private suspend fun logAddServiceApiKey(isApiKeyAdded: Boolean) {
+            analytics.logAddServiceApiKey(
+                weatherService = screen.weatherApiService,
+                isApiKeyAdded = isApiKeyAdded,
+                initiatedFromApiError = screen.isOriginatedFromError,
+            )
+        }
 
         @CircuitInject(BringYourOwnApiKeyScreen::class, AppScope::class)
         @AssistedFactory

--- a/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
@@ -119,7 +119,9 @@ class WeatherAlertDetailsPresenter
             var isEditingNote by remember { mutableStateOf(false) }
 
             LaunchedImpressionEffect {
+                val city = alertDao.getAlertWithCity(screen.alertId).city
                 analytics.logScreenView(WeatherAlertDetailsScreen::class)
+                analytics.logCityDetails(city.id, city.cityName)
             }
 
             LaunchedEffect(Unit) {

--- a/app/src/main/java/dev/hossain/weatheralert/util/Analytics.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/util/Analytics.kt
@@ -9,6 +9,7 @@ import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.optional.SingleIn
 import dev.hossain.weatheralert.data.WeatherService
 import dev.hossain.weatheralert.di.AppScope
+import dev.hossain.weatheralert.util.Analytics.Companion.EVENT_ADD_SERVICE_API_KEY
 import dev.hossain.weatheralert.util.Analytics.Companion.EVENT_WORKER_JOB_COMPLETED
 import dev.hossain.weatheralert.util.Analytics.Companion.EVENT_WORKER_JOB_FAILED
 import dev.hossain.weatheralert.util.Analytics.Companion.EVENT_WORKER_JOB_STARTED
@@ -23,6 +24,7 @@ interface Analytics {
         internal const val EVENT_WORKER_JOB_STARTED = "wa_worker_job_initiated"
         internal const val EVENT_WORKER_JOB_COMPLETED = "wa_worker_job_success"
         internal const val EVENT_WORKER_JOB_FAILED = "wa_worker_job_failed"
+        internal const val EVENT_ADD_SERVICE_API_KEY = "wa_add_service_api_key"
     }
 
     /**
@@ -51,6 +53,15 @@ interface Analytics {
     suspend fun logCityDetails(
         cityId: Long,
         cityName: String,
+    )
+
+    /**
+     * Logs attempt to add service API key.
+     */
+    suspend fun logAddServiceApiKey(
+        weatherService: WeatherService,
+        isApiKeyAdded: Boolean,
+        initiatedFromApiError: Boolean,
     )
 }
 
@@ -116,6 +127,19 @@ class AnalyticsImpl
                 param(FirebaseAnalytics.Param.ITEM_ID, cityId)
                 param(FirebaseAnalytics.Param.ITEM_NAME, cityName)
                 param(FirebaseAnalytics.Param.CONTENT_TYPE, "city")
+            }
+        }
+
+        override suspend fun logAddServiceApiKey(
+            weatherService: WeatherService,
+            isApiKeyAdded: Boolean,
+            initiatedFromApiError: Boolean,
+        ) {
+            firebaseAnalytics.logEvent(EVENT_ADD_SERVICE_API_KEY) {
+                // The result of an operation (long). Specify 1 to indicate success and 0 to indicate failure.
+                param(FirebaseAnalytics.Param.SUCCESS, if (isApiKeyAdded) 1L else 0L)
+                param(FirebaseAnalytics.Param.METHOD, weatherService.name)
+                param("directed_from_error", initiatedFromApiError.toString())
             }
         }
     }

--- a/app/src/main/java/dev/hossain/weatheralert/util/Analytics.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/util/Analytics.kt
@@ -9,6 +9,9 @@ import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.optional.SingleIn
 import dev.hossain.weatheralert.data.WeatherService
 import dev.hossain.weatheralert.di.AppScope
+import dev.hossain.weatheralert.util.Analytics.Companion.EVENT_WORKER_JOB_COMPLETED
+import dev.hossain.weatheralert.util.Analytics.Companion.EVENT_WORKER_JOB_FAILED
+import dev.hossain.weatheralert.util.Analytics.Companion.EVENT_WORKER_JOB_STARTED
 import javax.inject.Inject
 import kotlin.reflect.KClass
 
@@ -16,6 +19,12 @@ import kotlin.reflect.KClass
  * Interface for logging analytics events.
  */
 interface Analytics {
+    companion object {
+        internal const val EVENT_WORKER_JOB_STARTED = "wa_worker_job_initiated"
+        internal const val EVENT_WORKER_JOB_COMPLETED = "wa_worker_job_success"
+        internal const val EVENT_WORKER_JOB_FAILED = "wa_worker_job_failed"
+    }
+
     /**
      * Logs a screen view event.
      *
@@ -72,7 +81,7 @@ class AnalyticsImpl
             interval: Long,
             alertsCount: Long,
         ) {
-            firebaseAnalytics.logEvent("wa_worker_job_initiated") {
+            firebaseAnalytics.logEvent(EVENT_WORKER_JOB_STARTED) {
                 param("update_interval", interval)
                 param("alerts_count", alertsCount)
                 param(FirebaseAnalytics.Param.METHOD, weatherService.name)
@@ -80,7 +89,7 @@ class AnalyticsImpl
         }
 
         override suspend fun logWorkSuccess(weatherService: WeatherService) {
-            firebaseAnalytics.logEvent("wa_worker_job_success") {
+            firebaseAnalytics.logEvent(EVENT_WORKER_JOB_COMPLETED) {
                 // The result of an operation (long). Specify 1 to indicate success and 0 to indicate failure.
                 param(FirebaseAnalytics.Param.SUCCESS, 1L)
                 param(FirebaseAnalytics.Param.METHOD, weatherService.name)
@@ -91,7 +100,7 @@ class AnalyticsImpl
             weatherService: WeatherService,
             errorCode: Long,
         ) {
-            firebaseAnalytics.logEvent("wa_worker_job_success") {
+            firebaseAnalytics.logEvent(EVENT_WORKER_JOB_FAILED) {
                 // The result of an operation (long). Specify 1 to indicate success and 0 to indicate failure.
                 param(FirebaseAnalytics.Param.SUCCESS, 0L)
                 param(FirebaseAnalytics.Param.METHOD, weatherService.name)

--- a/app/src/main/java/dev/hossain/weatheralert/util/Analytics.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/util/Analytics.kt
@@ -7,6 +7,7 @@ import com.google.firebase.analytics.logEvent
 import com.slack.circuit.runtime.screen.Screen
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.optional.SingleIn
+import dev.hossain.weatheralert.data.WeatherService
 import dev.hossain.weatheralert.di.AppScope
 import javax.inject.Inject
 import kotlin.reflect.KClass
@@ -23,11 +24,25 @@ interface Analytics {
     suspend fun logScreenView(circuitScreen: KClass<out Screen>)
 
     suspend fun logWorkerJob(
+        weatherService: WeatherService,
         interval: Long,
         alertsCount: Long,
     )
 
-    suspend fun logWorkSuccess()
+    suspend fun logWorkSuccess(weatherService: WeatherService)
+
+    suspend fun logWorkFailed(
+        weatherService: WeatherService,
+        errorCode: Long = 0L,
+    )
+
+    /**
+     * Logs event when user selects a city to see alert details.
+     */
+    suspend fun logCityDetails(
+        cityId: Long,
+        cityName: String,
+    )
 }
 
 /**
@@ -53,16 +68,45 @@ class AnalyticsImpl
         }
 
         override suspend fun logWorkerJob(
+            weatherService: WeatherService,
             interval: Long,
             alertsCount: Long,
         ) {
             firebaseAnalytics.logEvent("wa_worker_job_initiated") {
                 param("update_interval", interval)
                 param("alerts_count", alertsCount)
+                param(FirebaseAnalytics.Param.METHOD, weatherService.name)
             }
         }
 
-        override suspend fun logWorkSuccess() {
-            firebaseAnalytics.logEvent("wa_worker_job_success") {}
+        override suspend fun logWorkSuccess(weatherService: WeatherService) {
+            firebaseAnalytics.logEvent("wa_worker_job_success") {
+                // The result of an operation (long). Specify 1 to indicate success and 0 to indicate failure.
+                param(FirebaseAnalytics.Param.SUCCESS, 1L)
+                param(FirebaseAnalytics.Param.METHOD, weatherService.name)
+            }
+        }
+
+        override suspend fun logWorkFailed(
+            weatherService: WeatherService,
+            errorCode: Long,
+        ) {
+            firebaseAnalytics.logEvent("wa_worker_job_success") {
+                // The result of an operation (long). Specify 1 to indicate success and 0 to indicate failure.
+                param(FirebaseAnalytics.Param.SUCCESS, 0L)
+                param(FirebaseAnalytics.Param.METHOD, weatherService.name)
+                param("error_code", errorCode)
+            }
+        }
+
+        override suspend fun logCityDetails(
+            cityId: Long,
+            cityName: String,
+        ) {
+            firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SELECT_ITEM) {
+                param(FirebaseAnalytics.Param.ITEM_ID, cityId)
+                param(FirebaseAnalytics.Param.ITEM_NAME, cityName)
+                param(FirebaseAnalytics.Param.CONTENT_TYPE, "city")
+            }
         }
     }

--- a/app/src/main/java/dev/hossain/weatheralert/work/WeatherCheckWorker.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/work/WeatherCheckWorker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.slack.eithernet.ApiResult
+import com.slack.eithernet.exceptionOrNull
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import dev.hossain.weatheralert.data.PreferencesManager
@@ -118,18 +119,34 @@ class WeatherCheckWorker
 
                     is ApiResult.Failure.HttpFailure -> {
                         logWorkerFailed(weatherService, forecastApiResult.code.toLong())
+                        Timber.e(
+                            forecastApiResult.exceptionOrNull(),
+                            "HttpFailure: Failed to fetch forecast for city: ${configuredAlert.city.cityName} using $weatherService.",
+                        )
                         return Result.retry()
                     }
 
                     is ApiResult.Failure.ApiFailure -> {
+                        Timber.e(
+                            forecastApiResult.exceptionOrNull(),
+                            "ApiFailure: Failed to fetch forecast for city: ${configuredAlert.city.cityName} using $weatherService.",
+                        )
                         return Result.failure()
                     }
 
                     is ApiResult.Failure.NetworkFailure -> {
+                        Timber.e(
+                            forecastApiResult.exceptionOrNull(),
+                            "NetworkFailure: Failed to fetch forecast for city: ${configuredAlert.city.cityName} using $weatherService.",
+                        )
                         return Result.retry()
                     }
 
                     is ApiResult.Failure.UnknownFailure -> {
+                        Timber.e(
+                            forecastApiResult.exceptionOrNull(),
+                            "UnknownFailure: Failed to fetch forecast for city: ${configuredAlert.city.cityName} using $weatherService.",
+                        )
                         logWorkerFailed(weatherService, 0L)
                         return Result.failure()
                     }


### PR DESCRIPTION
This pull request includes several changes to enhance the logging and analytics capabilities of the `weatheralert` application. The most important changes involve adding new logging methods for various events, updating existing methods to include more detailed information, and integrating these updates into different parts of the application.

### Enhancements to logging and analytics:

* Added a new method `logAddServiceApiKey` to log the addition of service API keys, and integrated it into the `BringYourOwnApiKeyPresenter` class to log both successful and failed attempts. [[1]](diffhunk://#diff-7207571ba3b25ab6b4f6cdaf53cb82e4ce64354a605d5bb85ad6778646e79bfbR178) [[2]](diffhunk://#diff-7207571ba3b25ab6b4f6cdaf53cb82e4ce64354a605d5bb85ad6778646e79bfbR190) [[3]](diffhunk://#diff-7207571ba3b25ab6b4f6cdaf53cb82e4ce64354a605d5bb85ad6778646e79bfbR234-R241)
* Introduced new constants for various events in the `Analytics` companion object, and added corresponding methods to log these events, including `logWorkerJob`, `logWorkSuccess`, `logWorkFailed`, `logCityDetails`, and `logAddServiceApiKey`. [[1]](diffhunk://#diff-81f82423b3354c3fa84383602f0148eed02a59e378a944adc2f45d99d448c8e3R10-R29) [[2]](diffhunk://#diff-81f82423b3354c3fa84383602f0148eed02a59e378a944adc2f45d99d448c8e3R38-R65)
* Updated the `AnalyticsImpl` class to implement the new logging methods, ensuring detailed information is logged for worker jobs, city details, and API key additions.

### Integration of new logging methods:

* Updated the `WeatherAlertDetailsPresenter` class to log city details when a city is selected to view alert details.
* Enhanced the `WeatherCheckWorker` class to log detailed information about the weather service used, including logging worker job initiation, success, and failure events with specific error codes. [[1]](diffhunk://#diff-7d7c214d676cf6d3c00899304e6c82ea3030a7806e53c343720114d07e971a5aR7-R12) [[2]](diffhunk://#diff-7d7c214d676cf6d3c00899304e6c82ea3030a7806e53c343720114d07e971a5aL39-R50) [[3]](diffhunk://#diff-7d7c214d676cf6d3c00899304e6c82ea3030a7806e53c343720114d07e971a5aR121-R150) [[4]](diffhunk://#diff-7d7c214d676cf6d3c00899304e6c82ea3030a7806e53c343720114d07e971a5aL139-R183)