### PR TITLE
[REFACTOR] Moved API key function to check user provided key.

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/data/PreferencesManager.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/data/PreferencesManager.kt
@@ -65,10 +65,30 @@ class PreferencesManager
             }
         }
 
+        /**
+         * @see removeApiKey
+         */
         suspend fun clearUserApiKeys() {
             dataStore.edit { preferences: MutablePreferences ->
                 preferences.remove(UserPreferences.openWeatherServiceApiKey)
                 preferences.remove(UserPreferences.tomorrowIoServiceApiKey)
+            }
+        }
+
+        /**
+         * @see clearUserApiKeys
+         */
+        suspend fun removeApiKey(service: WeatherService) {
+            when (service) {
+                WeatherService.OPEN_WEATHER_MAP ->
+                    dataStore.edit { preferences: MutablePreferences ->
+                        preferences.remove(UserPreferences.openWeatherServiceApiKey)
+                    }
+                WeatherService.TOMORROW_IO ->
+                    dataStore.edit { preferences: MutablePreferences ->
+                        preferences.remove(UserPreferences.tomorrowIoServiceApiKey)
+                    }
+                WeatherService.OPEN_METEO -> throw IllegalStateException("No API key needed for Open-Meteo")
             }
         }
 

--- a/app/src/main/java/dev/hossain/weatheralert/data/WeatherRepository.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/data/WeatherRepository.kt
@@ -189,7 +189,7 @@ class WeatherRepositoryImpl
         ): ApiResult<AppForecastData, Unit> {
             val apiResult =
                 openWeatherService.getDailyForecast(
-                    apiKey = apiKey.key,
+                    apiKey = apiKey.activeServiceApiKey,
                     latitude = latitude,
                     longitude = longitude,
                 )
@@ -216,7 +216,7 @@ class WeatherRepositoryImpl
             val apiResult =
                 tomorrowIoService.getWeatherForecast(
                     location = "$latitude,$longitude",
-                    apiKey = apiKey.key,
+                    apiKey = apiKey.activeServiceApiKey,
                 )
             return when (apiResult) {
                 is ApiResult.Success -> {

--- a/app/src/main/java/dev/hossain/weatheralert/ui/addapikey/ByoApiKeyScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/addapikey/ByoApiKeyScreen.kt
@@ -174,7 +174,7 @@ class BringYourOwnApiKeyPresenter
                                     logAddServiceApiKey(isApiKeyAdded = true)
                                     preferencesManager.saveUserApiKey(screen.weatherApiService, apiKey)
                                     snackbarData =
-                                        SnackbarData("✔️API key is valid and saved.", "Continue") {
+                                        SnackbarData("✔️ API key is valid and saved.", "Continue") {
                                             if (screen.isOriginatedFromError) {
                                                 navigator.pop()
                                             } else {

--- a/app/src/main/java/dev/hossain/weatheralert/ui/addapikey/ByoApiKeyScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/addapikey/ByoApiKeyScreen.kt
@@ -59,7 +59,6 @@ import com.slack.eithernet.ApiResult
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import dev.hossain.weatheralert.BuildConfig
 import dev.hossain.weatheralert.R
 import dev.hossain.weatheralert.data.ApiKey
 import dev.hossain.weatheralert.data.PreferencesManager
@@ -136,13 +135,11 @@ class BringYourOwnApiKeyPresenter
 
             LaunchedEffect(Unit) {
                 // Prepopulates the API key, IFF it was provided by user.
-                apiKeyProvider.key
-                    .takeIf { isUserProvidedApiKey(screen.weatherApiService, it) }
-                    ?.let {
-                        apiKey = it
-                        isUserProvidedApiKey = true
-                        isApiKeyValid = apiKeyProvider.isValidKey(screen.weatherApiService, apiKey)
-                    }
+                if (apiKeyProvider.hasUserProvidedApiKey(screen.weatherApiService)) {
+                    apiKey = apiKeyProvider.activeServiceApiKey
+                    isUserProvidedApiKey = true
+                    isApiKeyValid = apiKeyProvider.isValidKey(screen.weatherApiService, apiKey)
+                }
             }
 
             LaunchedImpressionEffect {
@@ -215,20 +212,6 @@ class BringYourOwnApiKeyPresenter
                 }
             }
         }
-
-        /**
-         * Internal function to check if the API key is provided by user,
-         * then it's used to display in the API input field.
-         */
-        private fun isUserProvidedApiKey(
-            weatherApiService: WeatherService,
-            apiKey: String,
-        ): Boolean =
-            when (weatherApiService) {
-                WeatherService.OPEN_WEATHER_MAP -> apiKey.isNotEmpty() && apiKey != BuildConfig.OPEN_WEATHER_API_KEY
-                WeatherService.TOMORROW_IO -> apiKey.isNotEmpty() && apiKey != BuildConfig.TOMORROW_IO_API_KEY
-                WeatherService.OPEN_METEO -> false
-            }
 
         private suspend fun logAddServiceApiKey(isApiKeyAdded: Boolean) {
             analytics.logAddServiceApiKey(

--- a/app/src/main/java/dev/hossain/weatheralert/ui/settings/UserSettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/settings/UserSettingsScreen.kt
@@ -165,7 +165,13 @@ class UserSettingsPresenter
                         scheduleWeatherAlertsWork(context = context, event.frequency)
                     }
 
-                    is UserSettingsScreen.Event.RemoveServiceApiKey -> TODO()
+                    is UserSettingsScreen.Event.RemoveServiceApiKey -> {
+                        Timber.d("Removing API key for service: ${event.service}")
+                        scope.launch {
+                            preferencesManager.removeApiKey(event.service)
+                        }
+                        isUserProvidedApiKeyInUse = false
+                    }
                 }
             }
         }

--- a/app/src/test/java/dev/hossain/weatheralert/data/ApiKeyTest.kt
+++ b/app/src/test/java/dev/hossain/weatheralert/data/ApiKeyTest.kt
@@ -3,6 +3,7 @@ package dev.hossain.weatheralert.data
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -14,7 +15,8 @@ import org.robolectric.RobolectricTestRunner
 class ApiKeyTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
 
-    private val apiKeyImpl = ApiKeyImpl(PreferencesManager(context))
+    private val preferencesManager = PreferencesManager(context)
+    private val apiKeyImpl = ApiKeyImpl(preferencesManager)
 
     @Test
     fun isValidKey_returnsTrueForValidOpenWeatherMap_key1() {
@@ -57,4 +59,22 @@ class ApiKeyTest {
         val isValid = apiKeyImpl.isValidKey(WeatherService.TOMORROW_IO, invalidKey)
         assertThat(isValid).isFalse()
     }
+
+    @Test
+    fun hasUserProvidedApiKey_returnsTrueWhenUserProvidedKey() =
+        runTest {
+            preferencesManager.saveUserApiKey(WeatherService.OPEN_WEATHER_MAP, "userProvidedKey")
+
+            val hasUserProvidedKey = apiKeyImpl.hasUserProvidedApiKey(WeatherService.OPEN_WEATHER_MAP)
+            assertThat(hasUserProvidedKey).isTrue()
+        }
+
+    @Test
+    fun hasUserProvidedApiKey_returnsFalseWhenUsingDefaultKey() =
+        runTest {
+            preferencesManager.saveUserApiKey(WeatherService.OPEN_WEATHER_MAP, "")
+
+            val hasUserProvidedKey = apiKeyImpl.hasUserProvidedApiKey(WeatherService.OPEN_WEATHER_MAP)
+            assertThat(hasUserProvidedKey).isFalse()
+        }
 }


### PR DESCRIPTION
Added buttons to modify and reset.

Fixes #190

----
This pull request includes significant changes to the `ApiKey` interface and its implementation, as well as updates to the `PreferencesManager`, `WeatherRepositoryImpl`, and various UI components to support the new API key handling functionality. The most important changes are summarized below:

### API Key Management Enhancements:
* [`app/src/main/java/dev/hossain/weatheralert/data/ApiKey.kt`](diffhunk://#diff-0cb2b319047c2492dcd3f1bdead27ab3dc26fdf7c816c7b2b4618b790f4c03a1L13-R20): Renamed `key` to `activeServiceApiKey` and added methods `apiKey(weatherService: WeatherService)` and `hasUserProvidedApiKey(weatherApiService: WeatherService)`. [[1]](diffhunk://#diff-0cb2b319047c2492dcd3f1bdead27ab3dc26fdf7c816c7b2b4618b790f4c03a1L13-R20) [[2]](diffhunk://#diff-0cb2b319047c2492dcd3f1bdead27ab3dc26fdf7c816c7b2b4618b790f4c03a1R33-R37)
* [`app/src/main/java/dev/hossain/weatheralert/data/ApiKey.kt`](diffhunk://#diff-0cb2b319047c2492dcd3f1bdead27ab3dc26fdf7c816c7b2b4618b790f4c03a1L43-L59): Updated `ApiKeyImpl` to implement the new methods and adjust existing logic to use `apiKey(weatherService: WeatherService)`. [[1]](diffhunk://#diff-0cb2b319047c2492dcd3f1bdead27ab3dc26fdf7c816c7b2b4618b790f4c03a1L43-L59) [[2]](diffhunk://#diff-0cb2b319047c2492dcd3f1bdead27ab3dc26fdf7c816c7b2b4618b790f4c03a1R88-R96)

### Preferences Management:
* [`app/src/main/java/dev/hossain/weatheralert/data/PreferencesManager.kt`](diffhunk://#diff-4bc3facd36345146af904e41af6b6d70e18c63e92528709f10f32a3e9c366cecR68-R94): Added `removeApiKey(service: WeatherService)` method to clear user-provided API keys for specific services.

### Weather Repository Updates:
* [`app/src/main/java/dev/hossain/weatheralert/data/WeatherRepository.kt`](diffhunk://#diff-c1ad11c599343f1578a839cb060917817f914545a82e281b8b8ab90d2014aa47L192-R192): Updated `WeatherRepositoryImpl` to use `activeServiceApiKey` instead of `key`. [[1]](diffhunk://#diff-c1ad11c599343f1578a839cb060917817f914545a82e281b8b8ab90d2014aa47L192-R192) [[2]](diffhunk://#diff-c1ad11c599343f1578a839cb060917817f914545a82e281b8b8ab90d2014aa47L219-R219)

### UI Enhancements:
* [`app/src/main/java/dev/hossain/weatheralert/ui/addapikey/ByoApiKeyScreen.kt`](diffhunk://#diff-7207571ba3b25ab6b4f6cdaf53cb82e4ce64354a605d5bb85ad6778646e79bfbL139-R139): Modified `BringYourOwnApiKeyPresenter` to use `hasUserProvidedApiKey` and `activeServiceApiKey`. Removed the internal `isUserProvidedApiKey` method. [[1]](diffhunk://#diff-7207571ba3b25ab6b4f6cdaf53cb82e4ce64354a605d5bb85ad6778646e79bfbL139-R139) [[2]](diffhunk://#diff-7207571ba3b25ab6b4f6cdaf53cb82e4ce64354a605d5bb85ad6778646e79bfbL219-L232)
* [`app/src/main/java/dev/hossain/weatheralert/ui/settings/UserSettingsScreen.kt`](diffhunk://#diff-ec663cff353f821ff981286e15fb767064ae30c617d2b17bb8752428e3dded97R88): Enhanced `UserSettingsScreen` to show whether a user-provided API key is in use and allow removing it. [[1]](diffhunk://#diff-ec663cff353f821ff981286e15fb767064ae30c617d2b17bb8752428e3dded97R88) [[2]](diffhunk://#diff-ec663cff353f821ff981286e15fb767064ae30c617d2b17bb8752428e3dded97R97-R100) [[3]](diffhunk://#diff-ec663cff353f821ff981286e15fb767064ae30c617d2b17bb8752428e3dded97R117-R131) [[4]](diffhunk://#diff-ec663cff353f821ff981286e15fb767064ae30c617d2b17bb8752428e3dded97R142) [[5]](diffhunk://#diff-ec663cff353f821ff981286e15fb767064ae30c617d2b17bb8752428e3dded97R167-R174) [[6]](diffhunk://#diff-ec663cff353f821ff981286e15fb767064ae30c617d2b17bb8752428e3dded97L224-R256) [[7]](diffhunk://#diff-ec663cff353f821ff981286e15fb767064ae30c617d2b17bb8752428e3dded97L244-R289) [[8]](diffhunk://#diff-ec663cff353f821ff981286e15fb767064ae30c617d2b17bb8752428e3dded97R415)

### Testing:
* [`app/src/test/java/dev/hossain/weatheralert/data/ApiKeyTest.kt`](diffhunk://#diff-759ea1cad67781705d6b9456e184c67d1a0b4b77ed721efa89856a2daf35afc0R6): Added tests for the new `hasUserProvidedApiKey` method. [[1]](diffhunk://#diff-759ea1cad67781705d6b9456e184c67d1a0b4b77ed721efa89856a2daf35afc0R6) [[2]](diffhunk://#diff-759ea1cad67781705d6b9456e184c67d1a0b4b77ed721efa89856a2daf35afc0L17-R19) [[3]](diffhunk://#diff-759ea1cad67781705d6b9456e184c67d1a0b4b77ed721efa89856a2daf35afc0R62-R79)