### PR TITLE
[UPDATE] Removed scheme based deep linking. Using screen directly.

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/MainActivity.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/MainActivity.kt
@@ -2,27 +2,26 @@ package dev.hossain.weatheralert
 
 import android.app.Activity
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.core.os.BundleCompat
 import com.slack.circuit.backstack.rememberSaveableBackStack
 import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
 import com.slack.circuit.foundation.NavigableCircuitContent
 import com.slack.circuit.foundation.rememberCircuitNavigator
 import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuitx.gesturenavigation.GestureNavigationDecoration
 import com.squareup.anvil.annotations.ContributesMultibinding
-import dev.hossain.weatheralert.deeplinking.DEEP_LINK_HOST_VIEW_ALERT
-import dev.hossain.weatheralert.deeplinking.getIdFromPath
+import dev.hossain.weatheralert.deeplinking.BUNDLE_KEY_DEEP_LINK_DESTINATION_SCREEN
 import dev.hossain.weatheralert.di.ActivityKey
 import dev.hossain.weatheralert.di.AppScope
 import dev.hossain.weatheralert.network.NetworkMonitor
 import dev.hossain.weatheralert.ui.alertslist.CurrentWeatherAlertScreen
-import dev.hossain.weatheralert.ui.details.WeatherAlertDetailsScreen
 import dev.hossain.weatheralert.ui.theme.WeatherAlertAppTheme
 import dev.hossain.weatheralert.ui.theme.dimensions
 import timber.log.Timber
@@ -42,8 +41,8 @@ class MainActivity
             super.onCreate(savedInstanceState)
 
             val action: String? = intent?.action
-            val data: Uri? = intent?.data
-            Timber.d("onCreate action: $action, data: $data, savedInstanceState: $savedInstanceState")
+            val bundle: Bundle? = intent?.extras
+            Timber.d("onCreate action: $action, bundle: $bundle, savedInstanceState: $savedInstanceState")
 
             enableEdgeToEdge()
 
@@ -86,16 +85,16 @@ class MainActivity
         }
 
         private fun handleDeepLink(intent: Intent) {
-            val dataUri: Uri? = intent.data
-            if (dataUri != null) {
-                when (dataUri.host) {
-                    DEEP_LINK_HOST_VIEW_ALERT -> {
-                        val alertId = getIdFromPath(dataUri)
-                        if (alertId != null) {
-                            navigator.goTo(WeatherAlertDetailsScreen(alertId))
-                        }
-                    }
+            val destinationScreen =
+                intent.extras?.let {
+                    BundleCompat.getParcelable(
+                        it,
+                        BUNDLE_KEY_DEEP_LINK_DESTINATION_SCREEN,
+                        Screen::class.java,
+                    )
                 }
+            if (destinationScreen != null) {
+                navigator.goTo(destinationScreen)
             }
         }
     }

--- a/app/src/main/java/dev/hossain/weatheralert/deeplinking/AppDeepLink.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/deeplinking/AppDeepLink.kt
@@ -1,22 +1,8 @@
 package dev.hossain.weatheralert.deeplinking
 
-import android.net.Uri
-import androidx.core.net.toUri
-
-internal const val DEEP_LINK_SCHEME = "weatheralert"
-internal const val DEEP_LINK_HOST_VIEW_ALERT = "view_alert"
+import com.slack.circuit.runtime.screen.Screen
 
 /**
- * Creates a deep link URI for the alert.
- *
- * For example: `weatheralert://view_alert/123`
+ * Bundle key for deep link destination [Screen].
  */
-internal fun createViewAlertDeeplinkUri(alertId: Long): Uri = "$DEEP_LINK_SCHEME://$DEEP_LINK_HOST_VIEW_ALERT/$alertId".toUri()
-
-/**
- * Extracts the alert id from the deep link URI.
- *
- * For example:
- * Get the alert id `123` from the path: `weatheralert://view_alert/123`
- */
-internal fun getIdFromPath(dataUri: Uri): Long? = dataUri.pathSegments.firstOrNull()?.toLongOrNull()
+internal const val BUNDLE_KEY_DEEP_LINK_DESTINATION_SCREEN = "destination_screen"

--- a/app/src/main/java/dev/hossain/weatheralert/notification/Notification.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/notification/Notification.kt
@@ -9,7 +9,8 @@ import androidx.annotation.DrawableRes
 import androidx.core.app.NotificationCompat
 import dev.hossain.weatheralert.R
 import dev.hossain.weatheralert.datamodel.WeatherAlertCategory
-import dev.hossain.weatheralert.deeplinking.createViewAlertDeeplinkUri
+import dev.hossain.weatheralert.deeplinking.BUNDLE_KEY_DEEP_LINK_DESTINATION_SCREEN
+import dev.hossain.weatheralert.ui.details.WeatherAlertDetailsScreen
 import dev.hossain.weatheralert.util.formatUnit
 import dev.hossain.weatheralert.util.stripMarkdownSyntax
 import timber.log.Timber
@@ -100,7 +101,7 @@ internal fun triggerNotification(
     val intent =
         context.packageManager.getLaunchIntentForPackage(context.packageName)?.apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
-            data = createViewAlertDeeplinkUri(userAlertId)
+            putExtra(BUNDLE_KEY_DEEP_LINK_DESTINATION_SCREEN, WeatherAlertDetailsScreen(userAlertId))
         }
     val pendingIntent =
         PendingIntent.getActivity(


### PR DESCRIPTION
Reverts most changes from https://github.com/hossain-khan/android-weather-alert/pull/198

Closes #192

Need to handle this later:
```
onCreate action: android.intent.action.MAIN, bundle: Bundle[mParcelledData.dataSize=192], savedInstanceState: null
```

----

This pull request includes several changes to improve the handling of deep links in the `MainActivity` and related files. The most important changes include replacing URI-based deep link handling with Bundle-based handling, updating imports, and modifying the notification system to use the new deep link approach.

### Deep link handling improvements:

* [`app/src/main/java/dev/hossain/weatheralert/MainActivity.kt`](diffhunk://#diff-0291a11f6833a291c9e4b06e8ed11290e1e59b78897beea5ef5df69cbca7596bR11-L25): Replaced URI-based deep link handling with Bundle-based handling by introducing `BUNDLE_KEY_DEEP_LINK_DESTINATION_SCREEN` and using `BundleCompat.getParcelable` to retrieve the destination screen. [[1]](diffhunk://#diff-0291a11f6833a291c9e4b06e8ed11290e1e59b78897beea5ef5df69cbca7596bR11-L25) [[2]](diffhunk://#diff-0291a11f6833a291c9e4b06e8ed11290e1e59b78897beea5ef5df69cbca7596bL45-R46) [[3]](diffhunk://#diff-0291a11f6833a291c9e4b06e8ed11290e1e59b78897beea5ef5df69cbca7596bL89-R98)

* [`app/src/main/java/dev/hossain/weatheralert/deeplinking/AppDeepLink.kt`](diffhunk://#diff-66f9285e9500dae0a5c79bd5bb0000f5cddc1a8fac78e9a4007a3ecaebaddbdeL3-R8): Removed URI-based deep link creation and extraction methods and added a constant for the Bundle key used in deep linking.

### Notification system update:

* [`app/src/main/java/dev/hossain/weatheralert/notification/Notification.kt`](diffhunk://#diff-d01caa7169b769592beba6bbb949045120344ef1abae3bdb3c29ead3121c43fcL12-R13): Updated the notification triggering method to use the new Bundle-based deep link approach by putting the destination screen in the intent extras. [[1]](diffhunk://#diff-d01caa7169b769592beba6bbb949045120344ef1abae3bdb3c29ead3121c43fcL12-R13) [[2]](diffhunk://#diff-d01caa7169b769592beba6bbb949045120344ef1abae3bdb3c29ead3121c43fcL103-R104)