### PR TITLE
[FIXED] Item hover state by adding click listener to card

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/ui/alertslist/CurrentAlertListScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/alertslist/CurrentAlertListScreen.kt
@@ -410,10 +410,7 @@ fun AlertTileGrid(
                 eventSink = eventSink,
                 modifier =
                     Modifier
-                        .animateItem()
-                        .clickable {
-                            eventSink(CurrentWeatherAlertScreen.Event.OnItemClicked(alertTileData.alertId))
-                        },
+                        .animateItem(),
             )
         }
     }
@@ -457,8 +454,8 @@ fun AlertTileItem(
                 data = alertTileData,
                 cardElevation = cardElevation,
                 iconResId = alertTileData.category.iconRes(),
+                eventSink = eventSink,
             )
-            // AlertTile(data = alertTileData, cardElevation, modifier = Modifier.fillMaxWidth())
         },
     )
 }
@@ -499,6 +496,7 @@ fun AlertListItem(
     cardElevation: Dp,
     @DrawableRes
     iconResId: Int,
+    eventSink: (CurrentWeatherAlertScreen.Event) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -512,7 +510,9 @@ fun AlertListItem(
                     } else {
                         Modifier
                     },
-                ),
+                ).clickable {
+                    eventSink(CurrentWeatherAlertScreen.Event.OnItemClicked(data.alertId))
+                },
         elevation = CardDefaults.cardElevation(cardElevation),
         shape = RoundedCornerShape(12.dp),
     ) {


### PR DESCRIPTION
This pull request includes changes to the `CurrentAlertListScreen.kt` file to improve the handling of item click events by refactoring the event sink logic. The most important changes include moving the click event handling to the `AlertListItem` function and ensuring the `eventSink` parameter is passed correctly.

Event handling improvements:

* [`app/src/main/java/dev/hossain/weatheralert/ui/alertslist/CurrentAlertListScreen.kt`](diffhunk://#diff-c0f02dfc83a62e65c85468cd4ccee601abcc5b28043761d536b34c84d218efe2L413-R413): Removed the `clickable` modifier from the `AlertTileGrid` function and added it to the `AlertListItem` function to centralize click event handling. [[1]](diffhunk://#diff-c0f02dfc83a62e65c85468cd4ccee601abcc5b28043761d536b34c84d218efe2L413-R413) [[2]](diffhunk://#diff-c0f02dfc83a62e65c85468cd4ccee601abcc5b28043761d536b34c84d218efe2L515-R515)
* [`app/src/main/java/dev/hossain/weatheralert/ui/alertslist/CurrentAlertListScreen.kt`](diffhunk://#diff-c0f02dfc83a62e65c85468cd4ccee601abcc5b28043761d536b34c84d218efe2R457-L461): Added the `eventSink` parameter to the `AlertTileItem` and `AlertListItem` functions to ensure the click events are properly handled. [[1]](diffhunk://#diff-c0f02dfc83a62e65c85468cd4ccee601abcc5b28043761d536b34c84d218efe2R457-L461) [[2]](diffhunk://#diff-c0f02dfc83a62e65c85468cd4ccee601abcc5b28043761d536b34c84d218efe2R499)