### PR TITLE
Revert "Update kotlin monorepo to v2.1.10"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.8.0"
 firebaseBom = "33.8.0"
-kotlin = "2.1.10"
+kotlin = "2.1.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitKtx = "1.2.1"

--- a/resources/simplemaps-snapshot/city-db-creator/build.gradle.kts
+++ b/resources/simplemaps-snapshot/city-db-creator/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.1.10"
+    kotlin("jvm") version "2.1.0"
 }
 
 group = "dev.hossain.citydb"


### PR DESCRIPTION
Reverts hossain-khan/android-weather-alert#235


```

Applying com.gradle.CommonCustomUserDataGradlePlugin with version 2.0.2 via init script |  
-- | --
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0. |  
  | ksp-2.1.0-1.0.29 is too old for kotlin-2.1.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.1.0.


```