### PR TITLE
[ADDED] 24 hour forecast data visualization for end user

### DIFF
--- a/app/schemas/dev.hossain.weatheralert.db.AppDatabase/5.json
+++ b/app/schemas/dev.hossain.weatheralert.db.AppDatabase/5.json
@@ -1,0 +1,269 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "6c2922be635856eaf2d06c47c19dd6c4",
+    "entities": [
+      {
+        "tableName": "cities",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`city` TEXT NOT NULL, `city_ascii` TEXT NOT NULL, `lat` REAL NOT NULL, `lng` REAL NOT NULL, `country` TEXT NOT NULL, `iso2` TEXT NOT NULL, `iso3` TEXT NOT NULL, `admin_name` TEXT, `capital` TEXT, `population` INTEGER, `id` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cityName",
+            "columnName": "city_ascii",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lat",
+            "columnName": "lat",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lng",
+            "columnName": "lng",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iso2",
+            "columnName": "iso2",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iso3",
+            "columnName": "iso3",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provStateName",
+            "columnName": "admin_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "capital",
+            "columnName": "capital",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "population",
+            "columnName": "population",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "idx_country",
+            "unique": false,
+            "columnNames": [
+              "country"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_country` ON `${TABLE_NAME}` (`country`)"
+          },
+          {
+            "name": "idx_city_ascii",
+            "unique": false,
+            "columnNames": [
+              "city_ascii"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_city_ascii` ON `${TABLE_NAME}` (`city_ascii`)"
+          },
+          {
+            "name": "idx_city",
+            "unique": false,
+            "columnNames": [
+              "city"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_city` ON `${TABLE_NAME}` (`city`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "alerts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `city_id` INTEGER NOT NULL, `alert_category` TEXT NOT NULL, `threshold` REAL NOT NULL, `notes` TEXT NOT NULL, FOREIGN KEY(`city_id`) REFERENCES `cities`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cityId",
+            "columnName": "city_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertCategory",
+            "columnName": "alert_category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "threshold",
+            "columnName": "threshold",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_alerts_city_id",
+            "unique": false,
+            "columnNames": [
+              "city_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_alerts_city_id` ON `${TABLE_NAME}` (`city_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "cities",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "city_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "city_forecasts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`forecast_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `cityId` INTEGER NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `dailyCumulativeSnow` REAL NOT NULL, `nextDaySnow` REAL NOT NULL, `dailyCumulativeRain` REAL NOT NULL, `nextDayRain` REAL NOT NULL, `forecastSourceService` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `hourlyPrecipitation` TEXT NOT NULL DEFAULT '[]')",
+        "fields": [
+          {
+            "fieldPath": "forecastId",
+            "columnName": "forecast_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cityId",
+            "columnName": "cityId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dailyCumulativeSnow",
+            "columnName": "dailyCumulativeSnow",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextDaySnow",
+            "columnName": "nextDaySnow",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dailyCumulativeRain",
+            "columnName": "dailyCumulativeRain",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextDayRain",
+            "columnName": "nextDayRain",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "forecastSourceService",
+            "columnName": "forecastSourceService",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hourlyPrecipitation",
+            "columnName": "hourlyPrecipitation",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "forecast_id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6c2922be635856eaf2d06c47c19dd6c4')"
+    ]
+  }
+}

--- a/app/src/main/java/dev/hossain/weatheralert/data/WeatherRepository.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/data/WeatherRepository.kt
@@ -272,6 +272,7 @@ class WeatherRepositoryImpl
                     dailyCumulativeRain = convertToAppForecastData.rain.dailyCumulativeRain,
                     nextDayRain = convertToAppForecastData.rain.nextDayRain,
                     forecastSourceService = weatherService,
+                    hourlyPrecipitation = emptyList(), // TODO - Add hourly precipitation data
                 ),
             )
         }

--- a/app/src/main/java/dev/hossain/weatheralert/data/WeatherRepository.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/data/WeatherRepository.kt
@@ -272,7 +272,7 @@ class WeatherRepositoryImpl
                     dailyCumulativeRain = convertToAppForecastData.rain.dailyCumulativeRain,
                     nextDayRain = convertToAppForecastData.rain.nextDayRain,
                     forecastSourceService = weatherService,
-                    hourlyPrecipitation = emptyList(), // TODO - Add hourly precipitation data
+                    hourlyPrecipitation = convertToAppForecastData.hourlyPrecipitation,
                 ),
             )
         }
@@ -293,5 +293,6 @@ class WeatherRepositoryImpl
                         nextDayRain = cityForecast.nextDayRain,
                         weeklyCumulativeRain = 0.0,
                     ),
+                hourlyPrecipitation = cityForecast.hourlyPrecipitation,
             )
     }

--- a/app/src/main/java/dev/hossain/weatheralert/db/AppDatabase.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/db/AppDatabase.kt
@@ -3,6 +3,8 @@ package dev.hossain.weatheralert.db
 import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import dev.hossain.weatheralert.db.converter.Converters
 
 /**
  * Room database for the weather alert app.
@@ -12,14 +14,16 @@ import androidx.room.RoomDatabase
  */
 @Database(
     entities = [City::class, Alert::class, CityForecast::class],
-    version = 4,
+    version = 5,
     exportSchema = true,
     // https://developer.android.com/training/data-storage/room/migrating-db-versions
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 3, to = 4),
+        AutoMigration(from = 4, to = 5),
     ],
 )
+@TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun cityDao(): CityDao
 

--- a/app/src/main/java/dev/hossain/weatheralert/db/CityForecast.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/db/CityForecast.kt
@@ -3,10 +3,11 @@ package dev.hossain.weatheralert.db
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import dev.hossain.weatheralert.datamodel.HourlyPrecipitation
 import dev.hossain.weatheralert.datamodel.WeatherService
 
 @Entity(tableName = "city_forecasts")
-data class CityForecast(
+data class CityForecast constructor(
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "forecast_id")
     val forecastId: Long = 0,
@@ -20,4 +21,7 @@ data class CityForecast(
     val forecastSourceService: WeatherService,
     @ColumnInfo(name = "created_at")
     val createdAt: Long = System.currentTimeMillis(),
+    // Empty JSON array list by default
+    @ColumnInfo(defaultValue = "[]")
+    val hourlyPrecipitation: List<HourlyPrecipitation>,
 )

--- a/app/src/main/java/dev/hossain/weatheralert/db/converter/Converters.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/db/converter/Converters.kt
@@ -1,0 +1,19 @@
+package dev.hossain.weatheralert.db.converter
+
+import androidx.room.TypeConverter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dev.hossain.weatheralert.datamodel.HourlyPrecipitation
+
+class Converters {
+    private val moshi: Moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    private val type = Types.newParameterizedType(List::class.java, HourlyPrecipitation::class.java)
+    private val adapter = moshi.adapter<List<HourlyPrecipitation>>(type)
+
+    @TypeConverter
+    fun fromHourlyPrecipitationList(value: List<HourlyPrecipitation>): String = adapter.toJson(value)
+
+    @TypeConverter
+    fun toHourlyPrecipitationList(value: String): List<HourlyPrecipitation> = adapter.fromJson(value) ?: emptyList()
+}

--- a/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
@@ -524,7 +525,10 @@ private fun BarChartItem(
                     // Use 0.7 multiplier to avoid full height bar and keep space for labels
                     .fillMaxHeight(fraction = (value / maxValue).toFloat() * 0.7f)
                     .fillMaxWidth()
-                    .background(MaterialTheme.colorScheme.primary),
+                    .background(
+                        color = MaterialTheme.colorScheme.secondary,
+                        shape = RoundedCornerShape(topStart = 4.dp, topEnd = 4.dp),
+                    ),
         )
         Text(
             text = "$hour",

--- a/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
@@ -90,10 +90,12 @@ import dev.hossain.weatheralert.ui.serviceConfig
 import dev.hossain.weatheralert.ui.theme.WeatherAlertAppTheme
 import dev.hossain.weatheralert.ui.theme.dimensions
 import dev.hossain.weatheralert.util.Analytics
+import dev.hossain.weatheralert.util.convertIsoToHourAmPm
 import dev.hossain.weatheralert.util.formatTimestampToElapsedTime
 import dev.hossain.weatheralert.util.formatToDate
 import dev.hossain.weatheralert.util.formatUnit
 import dev.hossain.weatheralert.util.parseMarkdown
+import dev.hossain.weatheralert.util.slimTimeLabel
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import timber.log.Timber
@@ -319,7 +321,7 @@ fun WeatherAlertDetailsScreen(
                     }
                 } else {
                     item { CityInfoUi(city = city) }
-                    item { WeatherAlertConfigUi(alert = alert, forecast = cityForecast) }
+                    item { WeatherAlertForecastUi(alert = alert, forecast = cityForecast) }
                     item { WeatherAlertNoteUi(state = state) }
                     item { WeatherAlertUpdateOnUi(forecast = cityForecast) }
                     item { WeatherForecastSourceUi(forecastSourceService = cityForecast.forecastSourceService) }
@@ -392,7 +394,7 @@ fun CityInfoUi(
 }
 
 @Composable
-fun WeatherAlertConfigUi(
+fun WeatherAlertForecastUi(
     alert: Alert,
     forecast: CityForecast,
     modifier: Modifier = Modifier,
@@ -496,17 +498,25 @@ private fun PrecipitationChartUi(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            items(chartItems) { hour ->
+            items(chartItems) { itemIndex ->
                 val value =
                     if (weatherAlertCategory ==
                         WeatherAlertCategory.SNOW_FALL
                     ) {
-                        precipitationValues[hour].snow
+                        precipitationValues[itemIndex].snow
                     } else {
-                        precipitationValues[hour].rain
+                        precipitationValues[itemIndex].rain
                     }
+
                 BarChartItem(
-                    hour = hour,
+                    // Convert ISO 8601 date-time string to hour of the day.
+                    hourOfDayLabel =
+                        slimTimeLabel(
+                            hourOfDayLabel =
+                                convertIsoToHourAmPm(
+                                    isoDateTime = precipitationValues[itemIndex].isoDateTime,
+                                ),
+                        ),
                     value = value,
                     maxValue =
                         if (weatherAlertCategory ==
@@ -524,7 +534,7 @@ private fun PrecipitationChartUi(
 
 @Composable
 private fun BarChartItem(
-    hour: Int,
+    hourOfDayLabel: String,
     value: Double,
     maxValue: Double,
     modifier: Modifier = Modifier,
@@ -557,7 +567,7 @@ private fun BarChartItem(
                     ),
         )
         Text(
-            text = "$hour",
+            text = hourOfDayLabel,
             style = MaterialTheme.typography.labelSmall,
             modifier = Modifier.padding(top = 4.dp),
         )
@@ -874,7 +884,7 @@ fun PreviewPrecipitationChartUi() {
 fun PreviewBarChartItem() {
     WeatherAlertAppTheme {
         BarChartItem(
-            hour = 12,
+            hourOfDayLabel = "12p",
             value = 62.0,
             maxValue = 70.00,
             modifier = Modifier.padding(8.dp),

--- a/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
@@ -76,6 +76,7 @@ import dev.hossain.weatheralert.data.SnackbarData
 import dev.hossain.weatheralert.data.WeatherRepository
 import dev.hossain.weatheralert.data.iconRes
 import dev.hossain.weatheralert.datamodel.CUMULATIVE_DATA_HOURS_24
+import dev.hossain.weatheralert.datamodel.HourlyPrecipitation
 import dev.hossain.weatheralert.datamodel.WeatherAlertCategory
 import dev.hossain.weatheralert.datamodel.WeatherService
 import dev.hossain.weatheralert.db.Alert
@@ -770,6 +771,13 @@ private fun PreviewWeatherAlertDetailsScreen() {
                             dailyCumulativeRain = 100.0,
                             nextDayRain = 50.0,
                             forecastSourceService = WeatherService.OPEN_WEATHER_MAP,
+                            hourlyPrecipitation =
+                                listOf(
+                                    HourlyPrecipitation("2025-01-15T21:42:00Z", 5.0, 2.0),
+                                    HourlyPrecipitation("2025-01-15T22:42:00Z", 3.0, 1.5),
+                                    HourlyPrecipitation("2025-01-15T23:42:00Z", 4.0, 2.2),
+                                    HourlyPrecipitation("2025-01-16T00:42:00Z", 6.0, 3.1),
+                                ),
                         ),
                     alertNote = "Sample alert note\n* item 1\n* item 2",
                     isEditingNote = false,

--- a/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
@@ -459,7 +459,13 @@ fun WeatherAlertConfigUi(
                         }}",
                         style = MaterialTheme.typography.bodyLarge,
                     )
-                    if (forecast.hourlyPrecipitation.any { it.rain > 0 || it.snow > 0 }) {
+                    if (forecast.hourlyPrecipitation
+                            .take(CUMULATIVE_DATA_HOURS_24)
+                            .any {
+                                (alert.alertCategory == WeatherAlertCategory.RAIN_FALL && it.rain > 0) ||
+                                    (alert.alertCategory == WeatherAlertCategory.SNOW_FALL && it.snow > 0)
+                            }
+                    ) {
                         // Show precipitation chart only if there is any precipitation data.
                         Spacer(modifier = Modifier.height(16.dp))
                         PrecipitationChartUi(alert.alertCategory, forecast.hourlyPrecipitation)

--- a/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
@@ -432,7 +432,10 @@ fun WeatherAlertConfigUi(
                     painter = painterResource(id = alert.alertCategory.iconRes()),
                     contentDescription = "Alert Category",
                     tint = iconTint,
-                    modifier = Modifier.padding(16.dp).align(Alignment.TopEnd),
+                    modifier =
+                        Modifier
+                            .padding(16.dp)
+                            .align(Alignment.TopEnd),
                 )
                 Column(modifier = Modifier.padding(16.dp)) {
                     Text(
@@ -457,20 +460,10 @@ fun WeatherAlertConfigUi(
                         }}",
                         style = MaterialTheme.typography.bodyLarge,
                     )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        text = "24 Hour Forecast (mm)",
-                        style = MaterialTheme.typography.labelMedium,
-                        modifier = Modifier.padding(bottom = 8.dp),
-                    )
-                    LazyRow(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        items(24) { hour ->
-                            val value = precipitationValues[hour]
-                            BarChartItem(hour = hour, value = value, maxValue = maxValue)
-                        }
+                    if (precipitationValues.any { it > 0 }) {
+                        // Show precipitation chart only if there is any precipitation data.
+                        Spacer(modifier = Modifier.height(16.dp))
+                        PrecipitationChartUi(precipitationValues, maxValue)
                     }
                 }
             }
@@ -479,7 +472,31 @@ fun WeatherAlertConfigUi(
 }
 
 @Composable
-fun BarChartItem(
+private fun PrecipitationChartUi(
+    precipitationValues: List<Double>,
+    maxValue: Double,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = "24 Hour Forecast",
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(24) { hour ->
+                val value = precipitationValues[hour]
+                BarChartItem(hour = hour, value = value, maxValue = maxValue)
+            }
+        }
+    }
+}
+
+@Composable
+private fun BarChartItem(
     hour: Int,
     value: Double,
     maxValue: Double,
@@ -504,6 +521,7 @@ fun BarChartItem(
         Box(
             modifier =
                 Modifier
+                    // Use 0.7 multiplier to avoid full height bar and keep space for labels
                     .fillMaxHeight(fraction = (value / maxValue).toFloat() * 0.7f)
                     .fillMaxWidth()
                     .background(MaterialTheme.colorScheme.primary),
@@ -647,7 +665,10 @@ fun WeatherAlertUpdateOnUi(
                         text = "(${formatTimestampToElapsedTime(forecast.createdAt)})",
                         style = MaterialTheme.typography.bodySmall.copy(fontStyle = FontStyle.Italic),
                         // Extra padding for the icon on the right, to avoid overlap
-                        modifier = Modifier.padding(end = 24.dp).padding(top = 2.dp),
+                        modifier =
+                            Modifier
+                                .padding(end = 24.dp)
+                                .padding(top = 2.dp),
                     )
                 }
             }
@@ -784,6 +805,23 @@ private fun CityInfoUiPreview() {
                 modifier = Modifier.padding(paddingValues),
             )
         }
+    }
+}
+
+@Preview(showBackground = true, name = "PrecipitationChartUi Preview")
+@Preview(
+    showBackground = true,
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+    name = "PrecipitationChartUi Dark Mode",
+)
+@Composable
+fun PreviewPrecipitationChartUi() {
+    WeatherAlertAppTheme {
+        PrecipitationChartUi(
+            precipitationValues = List(24) { Random.nextDouble() * 100 },
+            maxValue = 100.0,
+            modifier = Modifier.padding(16.dp),
+        )
     }
 }
 

--- a/app/src/main/java/dev/hossain/weatheralert/util/DateFormatter.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/util/DateFormatter.kt
@@ -3,7 +3,9 @@ package dev.hossain.weatheralert.util
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 /**
@@ -14,6 +16,21 @@ fun formatToDate(timestamp: Long): String {
     val formatter = DateTimeFormatter.ofPattern("MMM d 'at' h:mm a")
     return dateTime.format(formatter)
 }
+
+fun convertIsoToHourAmPm(isoDateTime: String): String {
+    // Parse the ISO 8601 date-time string
+    val zonedDateTime = ZonedDateTime.parse(isoDateTime)
+
+    // Define a DateTimeFormatter to format the hour with AM/PM
+    val formatter = DateTimeFormatter.ofPattern("ha", Locale.ENGLISH)
+
+    // Format the ZonedDateTime to the desired format
+    val formattedTime = zonedDateTime.format(formatter)
+
+    return formattedTime
+}
+
+fun slimTimeLabel(hourOfDayLabel: String): String = hourOfDayLabel.replace("AM", "a").replace("PM", "p")
 
 fun formatTimestampToElapsedTime(timestamp: Long): String {
     val currentTime = System.currentTimeMillis()

--- a/app/src/test/java/dev/hossain/weatheralert/db/ConvertersTest.kt
+++ b/app/src/test/java/dev/hossain/weatheralert/db/ConvertersTest.kt
@@ -18,6 +18,7 @@ class ConvertersTest {
         converters = Converters()
     }
 
+    @Suppress("ktlint:standard:max-line-length")
     @Test
     fun testFromHourlyPrecipitationList() {
         val hourlyPrecipitationList =
@@ -27,26 +28,15 @@ class ConvertersTest {
             )
         val json = converters.fromHourlyPrecipitationList(hourlyPrecipitationList)
         // language=JSON
-        val expectedJson =
-            """
-            [
-                {"isoDateTime":"2025-01-15T21:42:00Z","rain":5.0,"snow":2.0},
-                {"isoDateTime":"2025-01-15T22:42:00Z","rain":3.0,"snow":1.0}
-            ]
-            """.trimIndent()
+        val expectedJson = """[{"isoDateTime":"2025-01-15T21:42:00Z","rain":5.0,"snow":2.0},{"isoDateTime":"2025-01-15T22:42:00Z","rain":3.0,"snow":1.0}]"""
         assertEquals(expectedJson, json)
     }
 
+    @Suppress("ktlint:standard:max-line-length")
     @Test
     fun testToHourlyPrecipitationList() {
         // language=JSON
-        val json =
-            """
-            [
-                {"isoDateTime":"2025-01-15T21:42:00Z","rain":5.0,"snow":2.0},
-                {"isoDateTime":"2025-01-15T22:42:00Z","rain":3.0,"snow":1.0}
-            ]
-            """.trimIndent()
+        val json = """[{"isoDateTime":"2025-01-15T21:42:00Z","rain":5.0,"snow":2.0},{"isoDateTime":"2025-01-15T22:42:00Z","rain":3.0,"snow":1.0}]"""
         val hourlyPrecipitationList = converters.toHourlyPrecipitationList(json)
         val expectedList =
             listOf(

--- a/app/src/test/java/dev/hossain/weatheralert/db/ConvertersTest.kt
+++ b/app/src/test/java/dev/hossain/weatheralert/db/ConvertersTest.kt
@@ -1,0 +1,66 @@
+package dev.hossain.weatheralert.db
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dev.hossain.weatheralert.datamodel.HourlyPrecipitation
+import dev.hossain.weatheralert.db.converter.Converters
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class ConvertersTest {
+    private lateinit var converters: Converters
+    private lateinit var moshi: Moshi
+
+    @Before
+    fun setUp() {
+        moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+        converters = Converters()
+    }
+
+    @Test
+    fun testFromHourlyPrecipitationList() {
+        val hourlyPrecipitationList =
+            listOf(
+                HourlyPrecipitation("2025-01-15T21:42:00Z", 5.0, 2.0),
+                HourlyPrecipitation("2025-01-15T22:42:00Z", 3.0, 1.0),
+            )
+        val json = converters.fromHourlyPrecipitationList(hourlyPrecipitationList)
+        // language=JSON
+        val expectedJson =
+            """
+            [
+                {"isoDateTime":"2025-01-15T21:42:00Z","rain":5.0,"snow":2.0},
+                {"isoDateTime":"2025-01-15T22:42:00Z","rain":3.0,"snow":1.0}
+            ]
+            """.trimIndent()
+        assertEquals(expectedJson, json)
+    }
+
+    @Test
+    fun testToHourlyPrecipitationList() {
+        // language=JSON
+        val json =
+            """
+            [
+                {"isoDateTime":"2025-01-15T21:42:00Z","rain":5.0,"snow":2.0},
+                {"isoDateTime":"2025-01-15T22:42:00Z","rain":3.0,"snow":1.0}
+            ]
+            """.trimIndent()
+        val hourlyPrecipitationList = converters.toHourlyPrecipitationList(json)
+        val expectedList =
+            listOf(
+                HourlyPrecipitation("2025-01-15T21:42:00Z", 5.0, 2.0),
+                HourlyPrecipitation("2025-01-15T22:42:00Z", 3.0, 1.0),
+            )
+        assertEquals(expectedList, hourlyPrecipitationList)
+    }
+
+    @Test
+    fun testToEmptyHourlyPrecipitationList() {
+        val json = "[]"
+        val hourlyPrecipitationList = converters.toHourlyPrecipitationList(json)
+        val expectedList = emptyList<HourlyPrecipitation>()
+        assertEquals(expectedList, hourlyPrecipitationList)
+    }
+}

--- a/app/src/test/java/dev/hossain/weatheralert/util/DateTimeFormatterTest.kt
+++ b/app/src/test/java/dev/hossain/weatheralert/util/DateTimeFormatterTest.kt
@@ -46,4 +46,32 @@ class DateTimeFormatterTest {
         val result = formatTimestampToElapsedTime(timestamp)
         assertThat(result).isEqualTo("1 hour ago")
     }
+
+    @Test
+    fun convertIsoToHourAmPm_validIsoDateTime() {
+        val isoDateTime = "2023-10-10T14:30:00Z"
+        val result = convertIsoToHourAmPm(isoDateTime)
+        assertThat(result).isEqualTo("2 PM")
+    }
+
+    @Test
+    fun convertIsoToHourAmPm_isoDateTimeWithMilliseconds() {
+        val isoDateTime = "2023-10-10T14:30:00.123Z"
+        val result = convertIsoToHourAmPm(isoDateTime)
+        assertThat(result).isEqualTo("2 PM")
+    }
+
+    @Test
+    fun convertIsoToHourAmPm_isoDateTimeWithOffset() {
+        val isoDateTime = "2023-10-10T14:30:00+02:00"
+        val result = convertIsoToHourAmPm(isoDateTime)
+        assertThat(result).isEqualTo("2 PM")
+    }
+
+    @Test
+    fun convertIsoToHourAmPm_isoDateTimeWithDifferentTimeZone() {
+        val isoDateTime = "2023-10-10T14:30:00-05:00"
+        val result = convertIsoToHourAmPm(isoDateTime)
+        assertThat(result).isEqualTo("2 PM")
+    }
 }

--- a/app/src/test/java/dev/hossain/weatheralert/util/DateTimeFormatterTest.kt
+++ b/app/src/test/java/dev/hossain/weatheralert/util/DateTimeFormatterTest.kt
@@ -51,27 +51,27 @@ class DateTimeFormatterTest {
     fun convertIsoToHourAmPm_validIsoDateTime() {
         val isoDateTime = "2023-10-10T14:30:00Z"
         val result = convertIsoToHourAmPm(isoDateTime)
-        assertThat(result).isEqualTo("2 PM")
+        assertThat(result).isEqualTo("2PM")
     }
 
     @Test
     fun convertIsoToHourAmPm_isoDateTimeWithMilliseconds() {
         val isoDateTime = "2023-10-10T14:30:00.123Z"
         val result = convertIsoToHourAmPm(isoDateTime)
-        assertThat(result).isEqualTo("2 PM")
+        assertThat(result).isEqualTo("2PM")
     }
 
     @Test
     fun convertIsoToHourAmPm_isoDateTimeWithOffset() {
         val isoDateTime = "2023-10-10T14:30:00+02:00"
         val result = convertIsoToHourAmPm(isoDateTime)
-        assertThat(result).isEqualTo("2 PM")
+        assertThat(result).isEqualTo("2PM")
     }
 
     @Test
     fun convertIsoToHourAmPm_isoDateTimeWithDifferentTimeZone() {
         val isoDateTime = "2023-10-10T14:30:00-05:00"
         val result = convertIsoToHourAmPm(isoDateTime)
-        assertThat(result).isEqualTo("2 PM")
+        assertThat(result).isEqualTo("2PM")
     }
 }

--- a/data-model/src/main/java/dev/hossain/weatheralert/datamodel/AppForecastData.kt
+++ b/data-model/src/main/java/dev/hossain/weatheralert/datamodel/AppForecastData.kt
@@ -8,6 +8,7 @@ data class AppForecastData(
     val longitude: Double = 0.0,
     val snow: Snow = Snow(),
     val rain: Rain = Rain(),
+    val hourlyPrecipitation: List<HourlyPrecipitation>,
 )
 
 data class Snow(

--- a/data-model/src/main/java/dev/hossain/weatheralert/datamodel/HourlyPrecipitation.kt
+++ b/data-model/src/main/java/dev/hossain/weatheralert/datamodel/HourlyPrecipitation.kt
@@ -8,6 +8,6 @@ data class HourlyPrecipitation(
      * @see DateTimeFormatter.ISO_DATE_TIME
      */
     val isoDateTime: String,
-    val rain: Double,
-    val snow: Double,
+    val rain: Double = 0.0,
+    val snow: Double = 0.0,
 )

--- a/data-model/src/main/java/dev/hossain/weatheralert/datamodel/HourlyPrecipitation.kt
+++ b/data-model/src/main/java/dev/hossain/weatheralert/datamodel/HourlyPrecipitation.kt
@@ -1,0 +1,13 @@
+package dev.hossain.weatheralert.datamodel
+
+import java.time.format.DateTimeFormatter
+
+data class HourlyPrecipitation(
+    /**
+     * ISO 8601 date-time string.
+     * @see DateTimeFormatter.ISO_DATE_TIME
+     */
+    val isoDateTime: String,
+    val rain: Double,
+    val snow: Double,
+)

--- a/service/openmeteo/src/main/java/com/openmeteo/api/OpenMeteoService.kt
+++ b/service/openmeteo/src/main/java/com/openmeteo/api/OpenMeteoService.kt
@@ -102,6 +102,7 @@ class OpenMeteoServiceImpl constructor() : OpenMeteoService {
                                 nextDayRain = nextDayRain,
                                 weeklyCumulativeRain = 0.0,
                             ),
+                        hourlyPrecipitation = emptyList(), // NOT IMPLEMENTED YET
                     ),
             )
         }

--- a/service/openweather/src/main/java/org/openweathermap/api/model/Converter.kt
+++ b/service/openweather/src/main/java/org/openweathermap/api/model/Converter.kt
@@ -2,8 +2,11 @@ package org.openweathermap.api.model
 
 import dev.hossain.weatheralert.datamodel.AppForecastData
 import dev.hossain.weatheralert.datamodel.CUMULATIVE_DATA_HOURS_24
+import dev.hossain.weatheralert.datamodel.HourlyPrecipitation
 import dev.hossain.weatheralert.datamodel.Rain
 import dev.hossain.weatheralert.datamodel.Snow
+import java.time.Instant
+import java.time.ZoneId
 
 /**
  * Extension function to convert a WeatherForecast object to an AppForecastData object.
@@ -39,4 +42,18 @@ internal fun WeatherForecast.toForecastData(): AppForecastData =
                         ?.rainVolume ?: 0.0,
                 weeklyCumulativeRain = 0.0,
             ),
+        hourlyPrecipitation = hourly.map { it.toHourlyPrecipitation() },
+    )
+
+private fun HourlyForecast.toHourlyPrecipitation(): HourlyPrecipitation =
+    HourlyPrecipitation(
+        // ISO-8601 date-time string.
+        isoDateTime =
+            Instant
+                .ofEpochSecond(date)
+                .atZone(ZoneId.systemDefault())
+                .toOffsetDateTime()
+                .toString(),
+        snow = snow?.snowVolumeInAnHour ?: 0.0,
+        rain = rain?.rainVolumeInAnHour ?: 0.0,
     )

--- a/service/tomorrowio/src/main/java/io/tomorrow/api/model/Converter.kt
+++ b/service/tomorrowio/src/main/java/io/tomorrow/api/model/Converter.kt
@@ -2,6 +2,7 @@ package io.tomorrow.api.model
 
 import dev.hossain.weatheralert.datamodel.AppForecastData
 import dev.hossain.weatheralert.datamodel.CUMULATIVE_DATA_HOURS_24
+import dev.hossain.weatheralert.datamodel.HourlyPrecipitation
 import dev.hossain.weatheralert.datamodel.Rain
 import dev.hossain.weatheralert.datamodel.Snow
 
@@ -41,4 +42,12 @@ internal fun WeatherResponse.toForecastData(): AppForecastData =
                         ?.rainAccumulation ?: 0.0,
                 weeklyCumulativeRain = 0.0,
             ),
+        hourlyPrecipitation = timelines.hourly.map { it.toHourlyPrecipitation() },
+    )
+
+private fun TimelineData.toHourlyPrecipitation(): HourlyPrecipitation =
+    HourlyPrecipitation(
+        isoDateTime = time,
+        snow = values.snowDepth ?: 0.0,
+        rain = values.rainAccumulation ?: 0.0,
     )


### PR DESCRIPTION
Closes https://github.com/hossain-khan/android-weather-alert/issues/243

This pull request includes significant updates to the database schema, repository implementation, and UI components to support hourly precipitation data. The most important changes include the addition of new database entities and fields, the introduction of type converters, and the modification of UI elements to display the new data.

### Database Schema Updates:
* Added new table definitions and updated existing ones to include `hourlyPrecipitation` in `app/schemas/dev.hossain.weatheralert.db.AppDatabase/5.json`.
* Updated `AppDatabase` to version 5 and included `TypeConverters` for handling complex data types. [[1]](diffhunk://#diff-73b4b00665db0cb912ade40d09fa460d5c07ac57482a87c4e51635099743e1e4R6-R7) [[2]](diffhunk://#diff-73b4b00665db0cb912ade40d09fa460d5c07ac57482a87c4e51635099743e1e4L15-R26)

### Repository Implementation:
* Modified `WeatherRepositoryImpl` to handle `hourlyPrecipitation` data in the forecast data retrieval and storage logic. [[1]](diffhunk://#diff-c1ad11c599343f1578a839cb060917817f914545a82e281b8b8ab90d2014aa47R275) [[2]](diffhunk://#diff-c1ad11c599343f1578a839cb060917817f914545a82e281b8b8ab90d2014aa47R296)

### Data Model:
* Updated `CityForecast` to include `hourlyPrecipitation` as a list of `HourlyPrecipitation` objects. [[1]](diffhunk://#diff-a3d3ebb7cdb986441327a4b549e73e003de3cd8bff3f423cc2ba1e7a4a27f54cR6-R10) [[2]](diffhunk://#diff-a3d3ebb7cdb986441327a4b549e73e003de3cd8bff3f423cc2ba1e7a4a27f54cR24-R26)

### Type Converters:
* Introduced `Converters` class to convert `hourlyPrecipitation` list to and from JSON using Moshi.

### UI Components:
* Updated `WeatherAlertDetails` screen to display hourly precipitation data using new composables and layout modifications. [[1]](diffhunk://#diff-71df08178d18f1d96c17beb1d43825683591ebc4f5dea55e9827fd5844c4891fR9-R23) [[2]](diffhunk://#diff-71df08178d18f1d96c17beb1d43825683591ebc4f5dea55e9827fd5844c4891fL311-R324) [[3]](diffhunk://#diff-71df08178d18f1d96c17beb1d43825683591ebc4f5dea55e9827fd5844c4891fL384-L389) [[4]](diffhunk://#diff-71df08178d18f1d96c17beb1d43825683591ebc4f5dea55e9827fd5844c4891fL424-R439)

----


![Screenshot_20250129_204948](https://github.com/user-attachments/assets/317438ea-1047-4d09-864f-3d53c9a94ef0)

---

![Screenshot_20250129_231836](https://github.com/user-attachments/assets/0f19849b-a01b-4ae2-96cb-70c8c4e14aa3)

