### PR TITLE
Db builder project cleanup

### DIFF
--- a/resources/simplemaps-data-snapshot/city-db-creator/README.md
+++ b/resources/simplemaps-data-snapshot/city-db-creator/README.md
@@ -35,16 +35,16 @@ Here is a snapshot of CSV data from each source
 
 
 ### Canada Cities
-| city      | city_ascii | province_id | province_name    | lat     | lng       | population | density | timezone          | ranking | postal              | id         |
-|-----------|------------|-------------|------------------|---------|-----------|------------|---------|-------------------|---------|---------------------|------------|
+| city      | city_ascii | province_id | province_name    | lat     | lng       | population | density | timezone          | ranking | postal | id         |
+|-----------|------------|-------------|------------------|---------|-----------|------------|---------|-------------------|---------|--------|------------|
 | Toronto   | Toronto    | ON          | Ontario          | 43.7417 | -79.3733  | 5647656    | 4427.8  | America/Toronto   | 1       | M5T... | 1124279679 |
 | Montréal  | Montreal   | QC          | Quebec           | 45.5089 | -73.5617  | 3675219    | 4833.5  | America/Toronto   | 1       | H1X... | 1124586170 |
 | Vancouver | Vancouver  | BC          | British Columbia | 49.2500 | -123.1000 | 2426160    | 5749.9  | America/Vancouver | 1       | V6Z... | 1124825478 |
 
 
 ### USA Cities
-| city        | city_ascii  | state_id | state_name | county_fips | county_name | lat     | lng       | population | density | source | military | incorporated | timezone            | ranking | zips                        | id         |
-|-------------|-------------|----------|------------|-------------|-------------|---------|-----------|------------|---------|--------|----------|--------------|---------------------|---------|-----------------------------|------------|
+| city        | city_ascii  | state_id | state_name | county_fips | county_name | lat     | lng       | population | density | source | military | incorporated | timezone            | ranking | zips     | id         |
+|-------------|-------------|----------|------------|-------------|-------------|---------|-----------|------------|---------|--------|----------|--------------|---------------------|---------|----------|------------|
 | New York    | New York    | NY       | New York   | 36081       | Queens      | 40.6943 | -73.9249  | 18908608   | 11080.3 | shape  | FALSE    | TRUE         | America/New_York    | 1       | 11229... | 1840034016 |
 | Los Angeles | Los Angeles | CA       | California | 06037       | Los Angeles | 34.1141 | -118.4068 | 11922389   | 3184.7  | shape  | FALSE    | TRUE         | America/Los_Angeles | 1       | 91367... | 1840020491 |
 | Chicago     | Chicago     | IL       | Illinois   | 17031       | Cook        | 41.8375 | -87.6866  | 8497759    | 4614.5  | shape  | FALSE    | TRUE         | America/Chicago     | 1       | 60018... | 1840000494 |

--- a/resources/simplemaps-data-snapshot/city-db-creator/src/main/kotlin/CheckCanadianCities.kt
+++ b/resources/simplemaps-data-snapshot/city-db-creator/src/main/kotlin/CheckCanadianCities.kt
@@ -1,7 +1,6 @@
 package dev.hossain.citydb
 
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
-import androidx.sqlite.use
 import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
 import dev.hossain.citydb.config.*
 import java.io.File

--- a/resources/simplemaps-data-snapshot/city-db-creator/src/main/kotlin/CheckUsaCities.kt
+++ b/resources/simplemaps-data-snapshot/city-db-creator/src/main/kotlin/CheckUsaCities.kt
@@ -1,7 +1,6 @@
 package dev.hossain.citydb
 
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
-import androidx.sqlite.use
 import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
 import dev.hossain.citydb.config.*
 import java.io.File

--- a/resources/simplemaps-data-snapshot/city-db-creator/src/main/kotlin/CityDbBuilder.kt
+++ b/resources/simplemaps-data-snapshot/city-db-creator/src/main/kotlin/CityDbBuilder.kt
@@ -2,7 +2,6 @@ package dev.hossain.citydb
 
 import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
-import androidx.sqlite.use
 import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
 import dev.hossain.citydb.config.*
 import java.io.BufferedWriter

--- a/resources/simplemaps-data-snapshot/city-db-creator/src/main/kotlin/DbTest.kt
+++ b/resources/simplemaps-data-snapshot/city-db-creator/src/main/kotlin/DbTest.kt
@@ -2,7 +2,6 @@ package dev.hossain.citydb
 
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import androidx.sqlite.execSQL
-import androidx.sqlite.use
 import dev.hossain.citydb.config.DB_FILE_NAME_TODO_TEST
 
 /**

--- a/resources/simplemaps-data-snapshot/city-db-creator/src/main/kotlin/config/DataFiles.kt
+++ b/resources/simplemaps-data-snapshot/city-db-creator/src/main/kotlin/config/DataFiles.kt
@@ -22,10 +22,12 @@ internal const val CANADA_COUNTRY_NAME = "Canada"
 internal const val DB_FILE_NAME_TODO_TEST = "db/todos.db"
 
 // File path for the original world cities database used by the alert app
+// File is location at PROJECT-ROOT/resources/simplemaps-data-snapshot
 internal const val DB_FILE_NAME_ALERT_APP = "../alertapp-original-world-cities.db"
 
 // File path for the enhanced database with additional USA and Canada cities
-internal const val DB_FILE_NAME_ENHANCED_DB = "../alertapp-add-on-usa-canada-cities.db"
+// File is location at PROJECT-ROOT/resources/simplemaps-data-snapshot
+internal const val DB_FILE_NAME_ENHANCED_DB = "../alertapp-merged-cities.db"
 
 // Table name for cities in the database
 internal const val DB_TABLE_NAME_CITIES = "cities"

--- a/resources/simplemaps-data-snapshot/city-db-creator/src/main/kotlin/config/DataFiles.kt
+++ b/resources/simplemaps-data-snapshot/city-db-creator/src/main/kotlin/config/DataFiles.kt
@@ -1,25 +1,70 @@
 package dev.hossain.citydb.config
 
+// ISO 2-letter country code for the United States
 internal const val USA_COUNTRY_CODE_ISO2 = "US"
+
+// ISO 3-letter country code for the United States
 internal const val USA_COUNTRY_CODE_ISO3 = "USA"
+
+// Full country name for the United States
 internal const val USA_COUNTRY_NAME = "United States"
+
+// ISO 2-letter country code for Canada
 internal const val CANADA_COUNTRY_CODE_ISO2 = "CA"
+
+// ISO 3-letter country code for Canada
 internal const val CANADA_COUNTRY_CODE_ISO3 = "CAN"
+
+// Full country name for Canada
 internal const val CANADA_COUNTRY_NAME = "Canada"
+
+// File path for the TODOs test database that uses sample code from Android documentation
 internal const val DB_FILE_NAME_TODO_TEST = "db/todos.db"
+
+// File path for the original world cities database used by the alert app
 internal const val DB_FILE_NAME_ALERT_APP = "../alertapp-original-world-cities.db"
+
+// File path for the enhanced database with additional USA and Canada cities
 internal const val DB_FILE_NAME_ENHANCED_DB = "../alertapp-add-on-usa-canada-cities.db"
+
+// Table name for cities in the database
 internal const val DB_TABLE_NAME_CITIES = "cities"
+
+// ID offset for Canadian cities to avoid collisions with existing IDs
+// So, item id with 1124279679 will be 1000000000000 + 1124279679 = 1001124279679
 internal const val CANADA_CITY_ID_MUSK = 1000000000000
+
+// ID offset for USA cities to avoid collisions with existing IDs
+// So, item id with 1840034016 will be 2000000000000 + 1840034016 = 2001840034016
 internal const val USA_CITY_ID_MUSK = 2000000000000
+
+// File path for the CSV file containing world cities data
 internal const val CSV_WORLD_CITIES = "../simplemaps_worldcities_basic/worldcities.csv"
+
+// File path for the CSV file containing Canadian cities data
 internal const val CSV_CANADIAN_CITIES = "../simplemaps_canadacities_basic/canadacities.csv"
+
+// File path for the CSV file containing USA cities data
 internal const val CSV_USA_CITIES = "../simplemaps_uscities_basic/uscities.csv"
+
+// File path for the report of matched USA cities
 internal const val USA_CITIES_MATCHED_REPORT = "src/main/resources/CheckUsaCities.txt"
+
+// File path for the report of added USA cities
 internal const val USA_CITIES_ADD_REPORT = "src/main/resources/AddUsaCities.txt"
+
+// File path for the report of matched Canadian cities
 internal const val CANADA_CITIES_MATCHED_REPORT = "src/main/resources/CheckCanadianCities.txt"
+
+// File path for the report of added Canadian cities
 internal const val CANADA_CITIES_ADD_REPORT = "src/main/resources/AddCanadianCities.txt"
 
+/**
+ * Escapes single quotes in the input string by replacing them with two single quotes.
+ *
+ * @param input The input string to escape.
+ * @return The escaped string with single quotes replaced by two single quotes.
+ */
 fun escapeSingleQuote(input: String): String {
     return input.replace("'", "''")
 }


### PR DESCRIPTION
This pull request includes several changes to the `resources/simplemaps-data-snapshot/city-db-creator` project. The most important changes involve removing unused imports, updating table formatting in the README, and adding constants for country codes and file paths.

### Codebase simplification:

* Removed unused `import androidx.sqlite.use` statements from multiple Kotlin files (`CheckCanadianCities.kt`, `CheckUsaCities.kt`, `CityDbBuilder.kt`, `DbTest.kt`). [[1]](diffhunk://#diff-0651fbdea62df264704ffa6fc0786af6cf73c91d143063acb80d0c987d21c52dL4) [[2]](diffhunk://#diff-14c8fc4428f77df608062d74e397b56ead544ef18b0123b076ae4172d50b5f00L4) [[3]](diffhunk://#diff-a11f1d473a159db1b9aa82e445e06b5fb4291a2913b5bb43d93ccd4ca5ab7656L5) [[4]](diffhunk://#diff-36b3ed32ec3d39907c77e515d4f74b30bdf76b1c830f66ee0cc290415bb6d498L5)

### Documentation update:

* Updated table formatting in `README.md` to fix column alignment for Canada and USA cities tables.

### Configuration enhancements:

* Added constants for country codes, country names, file paths, table names, and ID offsets in `DataFiles.kt` to improve code readability and maintainability.