### PR TITLE
[UPDATE] Using local time zone time for hourly forecast chart

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
@@ -551,7 +551,7 @@ private fun BarChartItem(
                 .width(30.dp),
     ) {
         Text(
-            text = if(value == 0.0) "•" else "%.1f".format(value),
+            text = if (value == 0.0) "•" else "%.1f".format(value),
             style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp),
             modifier =
                 Modifier

--- a/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/details/WeatherAlertDetails.kt
@@ -101,6 +101,9 @@ import kotlinx.parcelize.Parcelize
 import timber.log.Timber
 import kotlin.random.Random
 
+/**
+ * Screen to show details of a weather alert.
+ */
 @Parcelize
 data class WeatherAlertDetailsScreen(
     val alertId: Long,
@@ -548,7 +551,7 @@ private fun BarChartItem(
                 .width(30.dp),
     ) {
         Text(
-            text = "%.1f".format(value),
+            text = if(value == 0.0) "•" else "%.1f".format(value),
             style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp),
             modifier =
                 Modifier

--- a/service/openweather/src/test/java/org/openweathermap/api/WeatherForecastConverterTest.kt
+++ b/service/openweather/src/test/java/org/openweathermap/api/WeatherForecastConverterTest.kt
@@ -26,6 +26,23 @@ class WeatherForecastConverterTest {
         assertThat(result.rain.nextDayRain).isEqualTo(0.0)
         assertThat(result.rain.weeklyCumulativeRain).isEqualTo(0.0)
     }
+    @Test
+    fun convertsWeatherForecastToAppForecastData_withHourlyData() {
+        val weatherForecast = loadWeatherForecastFromJson("open-weather-hourly-rain-colombo.json")
+
+        val result = weatherForecast.convertToForecastData()
+
+        // Validate hourly data
+        assertThat(result.hourlyPrecipitation.size).isEqualTo(48)
+
+
+        // First timestamp is 1738375200
+        // GMT	Sat Feb 01 2025 02:00:00 GMT+0000
+        // Your Time Zone Fri Jan 31 2025 21:00:00 GMT-0500 (Eastern Standard Time)
+        // Expected: Unix timestamp should be converted to local time zone
+
+        assertThat(result.hourlyPrecipitation[0].isoDateTime).isEqualTo("2025-01-31T21:00-05:00")
+    }
 
     @Test
     fun handlesEmptyHourlyAndDailyForecasts() {

--- a/service/openweather/src/test/java/org/openweathermap/api/WeatherForecastConverterTest.kt
+++ b/service/openweather/src/test/java/org/openweathermap/api/WeatherForecastConverterTest.kt
@@ -4,13 +4,30 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.Moshi
 import dev.hossain.weatheralert.datamodel.AppForecastData
 import dev.hossain.weatheralert.datamodel.WeatherApiServiceResponse
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.openweathermap.api.model.WeatherForecast
+import java.util.TimeZone
 
 /**
  * Tests [WeatherForecast] to [AppForecastData] conversion.
  */
 class WeatherForecastConverterTest {
+    private val originalTimeZone = TimeZone.getDefault()
+
+    @Before
+    fun setUp() {
+        // Set the default time zone to a specific time zone (e.g., "America/Toronto")
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Toronto"))
+    }
+
+    @After
+    fun tearDown() {
+        // Restore the original time zone after the test
+        TimeZone.setDefault(originalTimeZone)
+    }
+
     @Test
     fun convertsWeatherForecastToAppForecastData() {
         val weatherForecast = loadWeatherForecastFromJson("open-weather-hourly-snow-oshawa.json")
@@ -26,6 +43,7 @@ class WeatherForecastConverterTest {
         assertThat(result.rain.nextDayRain).isEqualTo(0.0)
         assertThat(result.rain.weeklyCumulativeRain).isEqualTo(0.0)
     }
+
     @Test
     fun convertsWeatherForecastToAppForecastData_withHourlyData() {
         val weatherForecast = loadWeatherForecastFromJson("open-weather-hourly-rain-colombo.json")
@@ -34,7 +52,6 @@ class WeatherForecastConverterTest {
 
         // Validate hourly data
         assertThat(result.hourlyPrecipitation.size).isEqualTo(48)
-
 
         // First timestamp is 1738375200
         // GMT	Sat Feb 01 2025 02:00:00 GMT+0000

--- a/service/openweather/src/test/resources/open-weather-hourly-rain-colombo.json
+++ b/service/openweather/src/test/resources/open-weather-hourly-rain-colombo.json
@@ -1,0 +1,1461 @@
+{
+  "X-REQUEST-URL": "https://api.openweathermap.org/data/3.0/onecall?appid=123&lat=6.9344&lon=79.8428&exclude=current%2Cminutely&units=metric",
+  "X-REQUEST-TIME-UTC": "2025-02-01T02:30:00Z",
+  "X-REQUEST-TIME-LOCAL": "Fri Jan 31 2025 21:31:34 GMT-0500 (Eastern Standard Time)",
+  "lat": 6.9344,
+  "lon": 79.8428,
+  "timezone": "Asia/Colombo",
+  "timezone_offset": 19800,
+  "hourly": [
+    {
+      "dt": 1738375200,
+      "temp": 25,
+      "feels_like": 25.85,
+      "pressure": 1011,
+      "humidity": 88,
+      "dew_point": 22.87,
+      "uvi": 0.71,
+      "clouds": 81,
+      "visibility": 10000,
+      "wind_speed": 2.94,
+      "wind_deg": 57,
+      "wind_gust": 2.87,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738378800,
+      "temp": 25.1,
+      "feels_like": 25.94,
+      "pressure": 1011,
+      "humidity": 87,
+      "dew_point": 22.78,
+      "uvi": 2.46,
+      "clouds": 80,
+      "visibility": 10000,
+      "wind_speed": 2.73,
+      "wind_deg": 47,
+      "wind_gust": 2.72,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738382400,
+      "temp": 25.6,
+      "feels_like": 26.41,
+      "pressure": 1011,
+      "humidity": 84,
+      "dew_point": 22.69,
+      "uvi": 5.33,
+      "clouds": 78,
+      "visibility": 10000,
+      "wind_speed": 2.73,
+      "wind_deg": 31,
+      "wind_gust": 2.78,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738386000,
+      "temp": 26.48,
+      "feels_like": 26.48,
+      "pressure": 1012,
+      "humidity": 79,
+      "dew_point": 22.54,
+      "uvi": 8.84,
+      "clouds": 67,
+      "visibility": 10000,
+      "wind_speed": 2.29,
+      "wind_deg": 360,
+      "wind_gust": 2.32,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738389600,
+      "temp": 27.47,
+      "feels_like": 30.22,
+      "pressure": 1011,
+      "humidity": 75,
+      "dew_point": 22.64,
+      "uvi": 11.26,
+      "clouds": 62,
+      "visibility": 10000,
+      "wind_speed": 2.74,
+      "wind_deg": 321,
+      "wind_gust": 2.53,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738393200,
+      "temp": 28.28,
+      "feels_like": 31.52,
+      "pressure": 1010,
+      "humidity": 72,
+      "dew_point": 22.45,
+      "uvi": 11.86,
+      "clouds": 64,
+      "visibility": 10000,
+      "wind_speed": 3.38,
+      "wind_deg": 304,
+      "wind_gust": 3.07,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738396800,
+      "temp": 28.12,
+      "feels_like": 31.18,
+      "pressure": 1009,
+      "humidity": 72,
+      "dew_point": 22.22,
+      "uvi": 10.12,
+      "clouds": 52,
+      "visibility": 10000,
+      "wind_speed": 4.24,
+      "wind_deg": 293,
+      "wind_gust": 3.88,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738400400,
+      "temp": 27.79,
+      "feels_like": 30.64,
+      "pressure": 1008,
+      "humidity": 73,
+      "dew_point": 22.37,
+      "uvi": 7.18,
+      "clouds": 50,
+      "visibility": 10000,
+      "wind_speed": 4.89,
+      "wind_deg": 298,
+      "wind_gust": 4.74,
+      "weather": [
+        {
+          "id": 802,
+          "main": "Clouds",
+          "description": "scattered clouds",
+          "icon": "03d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738404000,
+      "temp": 27.65,
+      "feels_like": 30.48,
+      "pressure": 1007,
+      "humidity": 74,
+      "dew_point": 22.81,
+      "uvi": 3.79,
+      "clouds": 53,
+      "visibility": 10000,
+      "wind_speed": 5.49,
+      "wind_deg": 295,
+      "wind_gust": 5.65,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738407600,
+      "temp": 28.06,
+      "feels_like": 31.2,
+      "pressure": 1007,
+      "humidity": 73,
+      "dew_point": 22.89,
+      "uvi": 1.29,
+      "clouds": 61,
+      "visibility": 10000,
+      "wind_speed": 5.23,
+      "wind_deg": 287,
+      "wind_gust": 5.77,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738411200,
+      "temp": 28.34,
+      "feels_like": 32.12,
+      "pressure": 1008,
+      "humidity": 75,
+      "dew_point": 23.44,
+      "uvi": 0.22,
+      "clouds": 57,
+      "visibility": 10000,
+      "wind_speed": 5.1,
+      "wind_deg": 298,
+      "wind_gust": 6.43,
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10d"
+        }
+      ],
+      "pop": 0.2,
+      "rain": {
+        "1h": 0.37
+      }
+    },
+    {
+      "dt": 1738414800,
+      "temp": 27.64,
+      "feels_like": 30.96,
+      "pressure": 1009,
+      "humidity": 78,
+      "dew_point": 23.49,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 5.89,
+      "wind_deg": 327,
+      "wind_gust": 6.39,
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10n"
+        }
+      ],
+      "pop": 1,
+      "rain": {
+        "1h": 0.83
+      }
+    },
+    {
+      "dt": 1738418400,
+      "temp": 27.51,
+      "feels_like": 30.78,
+      "pressure": 1010,
+      "humidity": 79,
+      "dew_point": 23.55,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 6.14,
+      "wind_deg": 348,
+      "wind_gust": 6.88,
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10n"
+        }
+      ],
+      "pop": 1,
+      "rain": {
+        "1h": 0.79
+      }
+    },
+    {
+      "dt": 1738422000,
+      "temp": 27.42,
+      "feels_like": 30.46,
+      "pressure": 1011,
+      "humidity": 78,
+      "dew_point": 23.3,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 6.07,
+      "wind_deg": 355,
+      "wind_gust": 6.56,
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10n"
+        }
+      ],
+      "pop": 1,
+      "rain": {
+        "1h": 0.77
+      }
+    },
+    {
+      "dt": 1738425600,
+      "temp": 26.7,
+      "feels_like": 29.16,
+      "pressure": 1011,
+      "humidity": 81,
+      "dew_point": 23.19,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 5.01,
+      "wind_deg": 12,
+      "wind_gust": 6.08,
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10n"
+        }
+      ],
+      "pop": 1,
+      "rain": {
+        "1h": 0.51
+      }
+    },
+    {
+      "dt": 1738429200,
+      "temp": 26.12,
+      "feels_like": 26.12,
+      "pressure": 1011,
+      "humidity": 83,
+      "dew_point": 22.85,
+      "uvi": 0,
+      "clouds": 94,
+      "visibility": 10000,
+      "wind_speed": 4.48,
+      "wind_deg": 35,
+      "wind_gust": 5.29,
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10n"
+        }
+      ],
+      "pop": 1,
+      "rain": {
+        "1h": 0.41
+      }
+    },
+    {
+      "dt": 1738432800,
+      "temp": 25.4,
+      "feels_like": 26.22,
+      "pressure": 1011,
+      "humidity": 85,
+      "dew_point": 22.56,
+      "uvi": 0,
+      "clouds": 92,
+      "visibility": 10000,
+      "wind_speed": 3.9,
+      "wind_deg": 47,
+      "wind_gust": 4.21,
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10n"
+        }
+      ],
+      "pop": 0.99,
+      "rain": {
+        "1h": 0.1
+      }
+    },
+    {
+      "dt": 1738436400,
+      "temp": 25.01,
+      "feels_like": 25.84,
+      "pressure": 1010,
+      "humidity": 87,
+      "dew_point": 22.54,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 3.98,
+      "wind_deg": 67,
+      "wind_gust": 4.14,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0.04
+    },
+    {
+      "dt": 1738440000,
+      "temp": 24.83,
+      "feels_like": 25.64,
+      "pressure": 1010,
+      "humidity": 87,
+      "dew_point": 22.52,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 4.43,
+      "wind_deg": 79,
+      "wind_gust": 4.9,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738443600,
+      "temp": 24.85,
+      "feels_like": 25.66,
+      "pressure": 1009,
+      "humidity": 87,
+      "dew_point": 22.44,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 4.37,
+      "wind_deg": 81,
+      "wind_gust": 4.96,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738447200,
+      "temp": 24.75,
+      "feels_like": 25.53,
+      "pressure": 1009,
+      "humidity": 86,
+      "dew_point": 22.15,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 4.28,
+      "wind_deg": 86,
+      "wind_gust": 4.69,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738450800,
+      "temp": 24.59,
+      "feels_like": 25.35,
+      "pressure": 1009,
+      "humidity": 86,
+      "dew_point": 22.02,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 3.69,
+      "wind_deg": 80,
+      "wind_gust": 3.8,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738454400,
+      "temp": 24.41,
+      "feels_like": 25.15,
+      "pressure": 1010,
+      "humidity": 86,
+      "dew_point": 21.86,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 3.08,
+      "wind_deg": 78,
+      "wind_gust": 3.1,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738458000,
+      "temp": 24.26,
+      "feels_like": 24.99,
+      "pressure": 1010,
+      "humidity": 86,
+      "dew_point": 21.72,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 2.71,
+      "wind_deg": 72,
+      "wind_gust": 2.67,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738461600,
+      "temp": 24.52,
+      "feels_like": 25.25,
+      "pressure": 1011,
+      "humidity": 85,
+      "dew_point": 21.73,
+      "uvi": 0.64,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 2.64,
+      "wind_deg": 70,
+      "wind_gust": 2.64,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738465200,
+      "temp": 25.2,
+      "feels_like": 25.89,
+      "pressure": 1012,
+      "humidity": 81,
+      "dew_point": 21.73,
+      "uvi": 2.34,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 2.35,
+      "wind_deg": 76,
+      "wind_gust": 2.34,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738468800,
+      "temp": 26.12,
+      "feels_like": 26.12,
+      "pressure": 1012,
+      "humidity": 77,
+      "dew_point": 21.75,
+      "uvi": 5.1,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 1.73,
+      "wind_deg": 84,
+      "wind_gust": 1.88,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738472400,
+      "temp": 26.94,
+      "feels_like": 29,
+      "pressure": 1012,
+      "humidity": 73,
+      "dew_point": 21.6,
+      "uvi": 8.09,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 0.55,
+      "wind_deg": 26,
+      "wind_gust": 0.69,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738476000,
+      "temp": 27.54,
+      "feels_like": 29.91,
+      "pressure": 1011,
+      "humidity": 71,
+      "dew_point": 21.67,
+      "uvi": 10.31,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 1.59,
+      "wind_deg": 307,
+      "wind_gust": 1.44,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738479600,
+      "temp": 27.71,
+      "feels_like": 30.23,
+      "pressure": 1010,
+      "humidity": 71,
+      "dew_point": 21.66,
+      "uvi": 11.03,
+      "clouds": 99,
+      "visibility": 10000,
+      "wind_speed": 2.96,
+      "wind_deg": 295,
+      "wind_gust": 2.75,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738483200,
+      "temp": 27.63,
+      "feels_like": 29.97,
+      "pressure": 1009,
+      "humidity": 70,
+      "dew_point": 21.24,
+      "uvi": 9.5,
+      "clouds": 85,
+      "visibility": 10000,
+      "wind_speed": 3.55,
+      "wind_deg": 279,
+      "wind_gust": 3.51,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738486800,
+      "temp": 27.57,
+      "feels_like": 29.75,
+      "pressure": 1008,
+      "humidity": 69,
+      "dew_point": 21.16,
+      "uvi": 6.69,
+      "clouds": 82,
+      "visibility": 10000,
+      "wind_speed": 4.37,
+      "wind_deg": 268,
+      "wind_gust": 4.27,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738490400,
+      "temp": 27.38,
+      "feels_like": 29.51,
+      "pressure": 1007,
+      "humidity": 70,
+      "dew_point": 21.55,
+      "uvi": 3.38,
+      "clouds": 86,
+      "visibility": 10000,
+      "wind_speed": 5.04,
+      "wind_deg": 261,
+      "wind_gust": 4.53,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738494000,
+      "temp": 27.51,
+      "feels_like": 29.86,
+      "pressure": 1007,
+      "humidity": 71,
+      "dew_point": 21.89,
+      "uvi": 1.14,
+      "clouds": 89,
+      "visibility": 10000,
+      "wind_speed": 5,
+      "wind_deg": 254,
+      "wind_gust": 4.79,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738497600,
+      "temp": 27.73,
+      "feels_like": 30.64,
+      "pressure": 1008,
+      "humidity": 74,
+      "dew_point": 22.74,
+      "uvi": 0.19,
+      "clouds": 91,
+      "visibility": 10000,
+      "wind_speed": 4.62,
+      "wind_deg": 262,
+      "wind_gust": 5.37,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738501200,
+      "temp": 27.39,
+      "feels_like": 30.4,
+      "pressure": 1008,
+      "humidity": 78,
+      "dew_point": 23.22,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 3.52,
+      "wind_deg": 276,
+      "wind_gust": 5.39,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738504800,
+      "temp": 27.26,
+      "feels_like": 30.44,
+      "pressure": 1009,
+      "humidity": 81,
+      "dew_point": 23.67,
+      "uvi": 0,
+      "clouds": 60,
+      "visibility": 10000,
+      "wind_speed": 2.71,
+      "wind_deg": 302,
+      "wind_gust": 5.06,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738508400,
+      "temp": 26.98,
+      "feels_like": 29.88,
+      "pressure": 1010,
+      "humidity": 82,
+      "dew_point": 23.58,
+      "uvi": 0,
+      "clouds": 80,
+      "visibility": 10000,
+      "wind_speed": 1.57,
+      "wind_deg": 7,
+      "wind_gust": 4.87,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738512000,
+      "temp": 26.33,
+      "feels_like": 26.33,
+      "pressure": 1011,
+      "humidity": 84,
+      "dew_point": 23.27,
+      "uvi": 0,
+      "clouds": 75,
+      "visibility": 10000,
+      "wind_speed": 2.06,
+      "wind_deg": 72,
+      "wind_gust": 5.4,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738515600,
+      "temp": 25.84,
+      "feels_like": 26.73,
+      "pressure": 1011,
+      "humidity": 86,
+      "dew_point": 23.22,
+      "uvi": 0,
+      "clouds": 62,
+      "visibility": 10000,
+      "wind_speed": 3.2,
+      "wind_deg": 104,
+      "wind_gust": 4.97,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738519200,
+      "temp": 25.82,
+      "feels_like": 26.73,
+      "pressure": 1010,
+      "humidity": 87,
+      "dew_point": 23.42,
+      "uvi": 0,
+      "clouds": 54,
+      "visibility": 10000,
+      "wind_speed": 3.78,
+      "wind_deg": 127,
+      "wind_gust": 4.71,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738522800,
+      "temp": 25.81,
+      "feels_like": 26.72,
+      "pressure": 1010,
+      "humidity": 87,
+      "dew_point": 23.31,
+      "uvi": 0,
+      "clouds": 26,
+      "visibility": 10000,
+      "wind_speed": 4.39,
+      "wind_deg": 133,
+      "wind_gust": 5.12,
+      "weather": [
+        {
+          "id": 802,
+          "main": "Clouds",
+          "description": "scattered clouds",
+          "icon": "03n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738526400,
+      "temp": 25.58,
+      "feels_like": 26.47,
+      "pressure": 1009,
+      "humidity": 87,
+      "dew_point": 23.2,
+      "uvi": 0,
+      "clouds": 26,
+      "visibility": 10000,
+      "wind_speed": 4.41,
+      "wind_deg": 131,
+      "wind_gust": 4.71,
+      "weather": [
+        {
+          "id": 802,
+          "main": "Clouds",
+          "description": "scattered clouds",
+          "icon": "03n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738530000,
+      "temp": 25.09,
+      "feels_like": 25.98,
+      "pressure": 1009,
+      "humidity": 89,
+      "dew_point": 23.05,
+      "uvi": 0,
+      "clouds": 33,
+      "visibility": 10000,
+      "wind_speed": 3.75,
+      "wind_deg": 120,
+      "wind_gust": 4,
+      "weather": [
+        {
+          "id": 802,
+          "main": "Clouds",
+          "description": "scattered clouds",
+          "icon": "03n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738533600,
+      "temp": 24.53,
+      "feels_like": 25.44,
+      "pressure": 1009,
+      "humidity": 92,
+      "dew_point": 23,
+      "uvi": 0,
+      "clouds": 35,
+      "visibility": 10000,
+      "wind_speed": 3.52,
+      "wind_deg": 96,
+      "wind_gust": 3.61,
+      "weather": [
+        {
+          "id": 802,
+          "main": "Clouds",
+          "description": "scattered clouds",
+          "icon": "03n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738537200,
+      "temp": 24.18,
+      "feels_like": 25.08,
+      "pressure": 1009,
+      "humidity": 93,
+      "dew_point": 22.86,
+      "uvi": 0,
+      "clouds": 45,
+      "visibility": 10000,
+      "wind_speed": 3.48,
+      "wind_deg": 84,
+      "wind_gust": 3.46,
+      "weather": [
+        {
+          "id": 802,
+          "main": "Clouds",
+          "description": "scattered clouds",
+          "icon": "03n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738540800,
+      "temp": 23.91,
+      "feels_like": 24.78,
+      "pressure": 1009,
+      "humidity": 93,
+      "dew_point": 22.72,
+      "uvi": 0,
+      "clouds": 54,
+      "visibility": 10000,
+      "wind_speed": 3.45,
+      "wind_deg": 64,
+      "wind_gust": 3.16,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1738544400,
+      "temp": 23.79,
+      "feels_like": 24.63,
+      "pressure": 1010,
+      "humidity": 92,
+      "dew_point": 22.42,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 3.23,
+      "wind_deg": 63,
+      "wind_gust": 3.05,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    }
+  ],
+  "daily": [
+    {
+      "dt": 1738391400,
+      "sunrise": 1738371553,
+      "sunset": 1738414143,
+      "moonrise": 1738379460,
+      "moonset": 1738423800,
+      "moon_phase": 0.1,
+      "summary": "Expect a day of partly cloudy with rain",
+      "temp": {
+        "day": 27.47,
+        "min": 24.78,
+        "max": 28.34,
+        "night": 25.4,
+        "eve": 28.34,
+        "morn": 24.78
+      },
+      "feels_like": {
+        "day": 30.22,
+        "night": 26.22,
+        "eve": 32.12,
+        "morn": 25.66
+      },
+      "pressure": 1011,
+      "humidity": 75,
+      "dew_point": 22.64,
+      "wind_speed": 6.14,
+      "wind_deg": 348,
+      "wind_gust": 6.88,
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10d"
+        }
+      ],
+      "clouds": 62,
+      "pop": 1,
+      "rain": 3.9,
+      "uvi": 11.86
+    },
+    {
+      "dt": 1738477800,
+      "sunrise": 1738457953,
+      "sunset": 1738500561,
+      "moonrise": 1738468560,
+      "moonset": 1738513320,
+      "moon_phase": 0.14,
+      "summary": "There will be partly cloudy today",
+      "temp": {
+        "day": 27.54,
+        "min": 24.26,
+        "max": 27.73,
+        "night": 25.82,
+        "eve": 27.73,
+        "morn": 24.41
+      },
+      "feels_like": {
+        "day": 29.91,
+        "night": 26.73,
+        "eve": 30.64,
+        "morn": 25.15
+      },
+      "pressure": 1011,
+      "humidity": 71,
+      "dew_point": 21.67,
+      "wind_speed": 5.04,
+      "wind_deg": 261,
+      "wind_gust": 5.4,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "clouds": 100,
+      "pop": 0.04,
+      "uvi": 11.03
+    },
+    {
+      "dt": 1738564200,
+      "sunrise": 1738544352,
+      "sunset": 1738586977,
+      "moonrise": 1738557660,
+      "moonset": 1738602840,
+      "moon_phase": 0.17,
+      "summary": "There will be partly cloudy today",
+      "temp": {
+        "day": 27.48,
+        "min": 23.79,
+        "max": 27.59,
+        "night": 25.25,
+        "eve": 27.34,
+        "morn": 23.91
+      },
+      "feels_like": {
+        "day": 29.69,
+        "night": 25.97,
+        "eve": 29.75,
+        "morn": 24.78
+      },
+      "pressure": 1011,
+      "humidity": 70,
+      "dew_point": 21.22,
+      "wind_speed": 4.41,
+      "wind_deg": 131,
+      "wind_gust": 5.37,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04d"
+        }
+      ],
+      "clouds": 56,
+      "pop": 0,
+      "uvi": 11.22
+    },
+    {
+      "dt": 1738650600,
+      "sunrise": 1738630749,
+      "sunset": 1738673393,
+      "moonrise": 1738646820,
+      "moonset": 1738692540,
+      "moon_phase": 0.21,
+      "summary": "The day will start with partly cloudy through the late morning hours, transitioning to rain",
+      "temp": {
+        "day": 27.14,
+        "min": 23.93,
+        "max": 27.14,
+        "night": 25.88,
+        "eve": 26.83,
+        "morn": 24.11
+      },
+      "feels_like": {
+        "day": 29.56,
+        "night": 26.61,
+        "eve": 29.04,
+        "morn": 24.9
+      },
+      "pressure": 1011,
+      "humidity": 75,
+      "dew_point": 22.1,
+      "wind_speed": 3.82,
+      "wind_deg": 250,
+      "wind_gust": 3.87,
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10d"
+        }
+      ],
+      "clouds": 89,
+      "pop": 0.56,
+      "rain": 1.23,
+      "uvi": 10.65
+    },
+    {
+      "dt": 1738737000,
+      "sunrise": 1738717146,
+      "sunset": 1738759809,
+      "moonrise": 1738736220,
+      "moonset": 0,
+      "moon_phase": 0.25,
+      "summary": "Expect a day of partly cloudy with rain",
+      "temp": {
+        "day": 27.18,
+        "min": 25.07,
+        "max": 27.18,
+        "night": 25.36,
+        "eve": 27.06,
+        "morn": 25.07
+      },
+      "feels_like": {
+        "day": 29.44,
+        "night": 25.96,
+        "eve": 28.79,
+        "morn": 25.75
+      },
+      "pressure": 1011,
+      "humidity": 73,
+      "dew_point": 21.83,
+      "wind_speed": 4.13,
+      "wind_deg": 295,
+      "wind_gust": 3.78,
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10d"
+        }
+      ],
+      "clouds": 71,
+      "pop": 0.39,
+      "rain": 0.95,
+      "uvi": 10.54
+    },
+    {
+      "dt": 1738823400,
+      "sunrise": 1738803542,
+      "sunset": 1738846223,
+      "moonrise": 1738825800,
+      "moonset": 1738782300,
+      "moon_phase": 0.28,
+      "summary": "You can expect partly cloudy in the morning, with clearing in the afternoon",
+      "temp": {
+        "day": 27.48,
+        "min": 24.39,
+        "max": 27.53,
+        "night": 25.5,
+        "eve": 27.12,
+        "morn": 24.39
+      },
+      "feels_like": {
+        "day": 29.91,
+        "night": 26.19,
+        "eve": 29.52,
+        "morn": 25.13
+      },
+      "pressure": 1010,
+      "humidity": 72,
+      "dew_point": 21.84,
+      "wind_speed": 4.95,
+      "wind_deg": 257,
+      "wind_gust": 4.57,
+      "weather": [
+        {
+          "id": 802,
+          "main": "Clouds",
+          "description": "scattered clouds",
+          "icon": "03d"
+        }
+      ],
+      "clouds": 33,
+      "pop": 0,
+      "uvi": 11
+    },
+    {
+      "dt": 1738909800,
+      "sunrise": 1738889937,
+      "sunset": 1738932637,
+      "moonrise": 1738915620,
+      "moonset": 1738872300,
+      "moon_phase": 0.32,
+      "summary": "Expect a day of partly cloudy with clear spells",
+      "temp": {
+        "day": 27.09,
+        "min": 24.11,
+        "max": 27.28,
+        "night": 25.94,
+        "eve": 27.28,
+        "morn": 24.11
+      },
+      "feels_like": {
+        "day": 29.46,
+        "night": 26.76,
+        "eve": 29.84,
+        "morn": 24.8
+      },
+      "pressure": 1010,
+      "humidity": 75,
+      "dew_point": 21.93,
+      "wind_speed": 4.64,
+      "wind_deg": 311,
+      "wind_gust": 5.55,
+      "weather": [
+        {
+          "id": 802,
+          "main": "Clouds",
+          "description": "scattered clouds",
+          "icon": "03d"
+        }
+      ],
+      "clouds": 39,
+      "pop": 0,
+      "uvi": 11
+    },
+    {
+      "dt": 1738996200,
+      "sunrise": 1738976331,
+      "sunset": 1739019050,
+      "moonrise": 1739005560,
+      "moonset": 1738962360,
+      "moon_phase": 0.35,
+      "summary": "There will be partly cloudy today",
+      "temp": {
+        "day": 27.81,
+        "min": 24.56,
+        "max": 27.81,
+        "night": 26.32,
+        "eve": 27.59,
+        "morn": 24.56
+      },
+      "feels_like": {
+        "day": 31.08,
+        "night": 26.32,
+        "eve": 29.78,
+        "morn": 25.42
+      },
+      "pressure": 1010,
+      "humidity": 76,
+      "dew_point": 22.89,
+      "wind_speed": 4.63,
+      "wind_deg": 306,
+      "wind_gust": 4.59,
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "broken clouds",
+          "icon": "04d"
+        }
+      ],
+      "clouds": 76,
+      "pop": 0.06,
+      "uvi": 11
+    }
+  ]
+}

--- a/service/tomorrowio/src/main/java/io/tomorrow/api/model/Converter.kt
+++ b/service/tomorrowio/src/main/java/io/tomorrow/api/model/Converter.kt
@@ -5,6 +5,9 @@ import dev.hossain.weatheralert.datamodel.CUMULATIVE_DATA_HOURS_24
 import dev.hossain.weatheralert.datamodel.HourlyPrecipitation
 import dev.hossain.weatheralert.datamodel.Rain
 import dev.hossain.weatheralert.datamodel.Snow
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
 /**
  * Extension function to convert a WeatherResponse object to an AppForecastData object.
@@ -45,9 +48,14 @@ internal fun WeatherResponse.toForecastData(): AppForecastData =
         hourlyPrecipitation = timelines.hourly.map { it.toHourlyPrecipitation() },
     )
 
-private fun TimelineData.toHourlyPrecipitation(): HourlyPrecipitation =
-    HourlyPrecipitation(
-        isoDateTime = time,
+private fun TimelineData.toHourlyPrecipitation(): HourlyPrecipitation {
+    val utcDateTime = ZonedDateTime.parse(time, DateTimeFormatter.ISO_DATE_TIME)
+    val localDateTime = utcDateTime.withZoneSameInstant(ZoneId.systemDefault())
+    val localIsoDateTime = localDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+
+    return HourlyPrecipitation(
+        isoDateTime = localIsoDateTime,
         snow = values.snowDepth ?: 0.0,
         rain = values.rainAccumulation ?: 0.0,
     )
+}


### PR DESCRIPTION
This pull request includes several changes to enhance the weather alert details screen and improve the accuracy of time zone handling in weather data conversion and testing. The most important changes include adding documentation, improving the display of bar chart values, and ensuring time zone consistency in weather forecast data.

### Enhancements to Weather Alert Details Screen:

* Added a documentation comment to the `WeatherAlertDetailsScreen` class to describe its purpose.
* Modified the `BarChartItem` function to display a dot instead of "0.0" when the value is zero.

### Improvements to Time Zone Handling in Weather Forecast Conversion:

* Added setup and teardown methods in `WeatherForecastConverterTest` to set and restore the default time zone before and after tests.
* Added a new test `convertsWeatherForecastToAppForecastData_withHourlyData` to validate the conversion of hourly precipitation data with proper time zone handling.
* Updated the `WeatherResponse.toForecastData` method to convert UTC date-time to the local time zone before formatting it as ISO offset date-time.
* Added setup and teardown methods in `WeatherResponseConverterTest` to set and restore the default time zone before and after tests.
* Added a new test `convertsBostonWeatherResponseToAppForecastData_hourlyDateTimeUpdatedToLocalZone` to validate the conversion of hourly precipitation data with proper time zone handling.