### PR TITLE
[ADDED] Change forecast service from the add alert screen.

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/ui/addalert/AddNewWeatherAlertScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/addalert/AddNewWeatherAlertScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -27,6 +28,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -96,6 +99,7 @@ import dev.hossain.weatheralert.db.City
 import dev.hossain.weatheralert.di.AppScope
 import dev.hossain.weatheralert.ui.addapikey.BringYourOwnApiKeyScreen
 import dev.hossain.weatheralert.ui.serviceConfig
+import dev.hossain.weatheralert.ui.settings.UserSettingsScreen
 import dev.hossain.weatheralert.ui.theme.WeatherAlertAppTheme
 import dev.hossain.weatheralert.ui.theme.dimensions
 import dev.hossain.weatheralert.util.Analytics
@@ -148,6 +152,8 @@ data class AddNewWeatherAlertScreen(
         ) : Event()
 
         data object GoBack : Event()
+
+        data object ForecastServiceIconClicked : Event()
     }
 }
 
@@ -359,6 +365,10 @@ class AddWeatherAlertPresenter
                         snackbarData = null
                         navigator.pop()
                     }
+
+                    AddNewWeatherAlertScreen.Event.ForecastServiceIconClicked -> {
+                        navigator.goTo(UserSettingsScreen("change-service"))
+                    }
                 }
             }
         }
@@ -420,7 +430,7 @@ fun AddNewWeatherAlertScreen(
             }
 
             state.selectedApiService?.let {
-                CurrentApiServiceStateUi(it)
+                CurrentApiServiceStateUi(it, state.eventSink)
             }
 
             EditableCityInputDropdownMenu(
@@ -552,6 +562,7 @@ fun AddNewWeatherAlertScreen(
 @Composable
 private fun CurrentApiServiceStateUi(
     weatherService: WeatherService,
+    eventSink: (AddNewWeatherAlertScreen.Event) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val serviceConfig = weatherService.serviceConfig()
@@ -560,12 +571,27 @@ private fun CurrentApiServiceStateUi(
         modifier = modifier,
     ) {
         Text("ℹ️ Forecast data source: ", style = MaterialTheme.typography.labelSmall)
-        Image(
-            painter = painterResource(id = serviceConfig.logoResId),
-            // tint = MaterialTheme.colorScheme.secondary,
-            modifier = Modifier.size(serviceConfig.logoWidth * 0.7f, serviceConfig.logoHeight * 0.7f),
-            contentDescription = "${weatherService.name} logo image",
-        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.clickable { eventSink(AddNewWeatherAlertScreen.Event.ForecastServiceIconClicked) },
+        ) {
+            Image(
+                painter = painterResource(id = serviceConfig.logoResId),
+                modifier =
+                    Modifier
+                        .size(serviceConfig.logoWidth * 0.7f, serviceConfig.logoHeight * 0.7f),
+                contentDescription = "${weatherService.name} logo image",
+            )
+            Spacer(modifier = Modifier.size(6.dp))
+            Icon(
+                imageVector = Icons.Outlined.Edit,
+                contentDescription = "Change forecast service",
+                tint = MaterialTheme.colorScheme.secondary.copy(alpha = 0.3f),
+                modifier =
+                    Modifier
+                        .size(14.dp),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
This pull request to `app/src/main/java/dev/hossain/weatheralert/ui/addalert/AddNewWeatherAlertScreen.kt` includes several changes to enhance the user interface and functionality of the Add New Weather Alert Screen. The most important changes include adding new import statements, creating a new event for clicking the forecast service icon, and modifying the `CurrentApiServiceStateUi` function to handle this new event.

Enhancements to user interface and functionality:

* Added new import statements for `Spacer`, `Edit` icons, and `UserSettingsScreen` to support new functionality and UI elements. [[1]](diffhunk://#diff-0cda03dd93f310418f322ace54d8695b5ca39959bb046709020731248bf66eeeR16) [[2]](diffhunk://#diff-0cda03dd93f310418f322ace54d8695b5ca39959bb046709020731248bf66eeeR31-R32) [[3]](diffhunk://#diff-0cda03dd93f310418f322ace54d8695b5ca39959bb046709020731248bf66eeeR102)
* Introduced a new event `ForecastServiceIconClicked` in the `AddNewWeatherAlertScreen` data class to handle user interactions with the forecast service icon.
* Updated the `AddWeatherAlertPresenter` class to navigate to the `UserSettingsScreen` when the `ForecastServiceIconClicked` event is triggered.
* Modified the `CurrentApiServiceStateUi` function to include an `eventSink` parameter and added a clickable `Row` containing the forecast service icon and an edit icon to trigger the new event. [[1]](diffhunk://#diff-0cda03dd93f310418f322ace54d8695b5ca39959bb046709020731248bf66eeeL423-R433) [[2]](diffhunk://#diff-0cda03dd93f310418f322ace54d8695b5ca39959bb046709020731248bf66eeeR565) [[3]](diffhunk://#diff-0cda03dd93f310418f322ace54d8695b5ca39959bb046709020731248bf66eeeR574-R594)