### PR TITLE
[ENABLED] Open meteo serice to test it out periodically for reliability

### DIFF
--- a/data-model/src/main/java/dev/hossain/weatheralert/datamodel/WeatherService.kt
+++ b/data-model/src/main/java/dev/hossain/weatheralert/datamodel/WeatherService.kt
@@ -36,9 +36,11 @@ enum class WeatherService(
      */
     OPEN_METEO(
         /**
-         * Disabled to service as the forecast data was not reliable.
+         * ⛔️ Disabled to service as the forecast data was not reliable.
          * See https://github.com/hossain-khan/android-weather-alert/pull/164
+         *
+         * ⚠️ UPDATE: This service is enabled **ONLY** for debug builds.
          */
-        isEnabled = false,
+        isEnabled = BuildConfig.DEBUG,
     ),
 }


### PR DESCRIPTION
This pull request includes a change to the `WeatherService` enum class in the `WeatherService.kt` file. The change updates the status of the `OPEN_METEO` service to be enabled only for debug builds and adds additional comments for clarity.

Changes to `WeatherService` enum class:

* Updated the `OPEN_METEO` service to be enabled only for debug builds by changing the `isEnabled` parameter to `BuildConfig.DEBUG`.
* Added a comment indicating that the service is enabled only for debug builds.
* Updated the comment to include a warning emoji and additional information about the service's status.