### PR TITLE
[REFACTOR] Simplify local props loading code

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,18 +48,14 @@ android {
         versionName = "2.3"
 
         // Read bundled API key from local.properties
-        val openWeatherApiKey: String =
-            project.rootProject.file("local.properties").takeIf { it.exists() }?.inputStream()?.use {
-                Properties().apply { load(it) }.getProperty("OPEN_WEATHER_API_KEY")
-            } ?: "API_KEY_FROM_local.properties"
-        val tomorrowIoApiKey: String =
-            project.rootProject.file("local.properties").takeIf { it.exists() }?.inputStream()?.use {
-                Properties().apply { load(it) }.getProperty("TOMORROW_IO_API_KEY")
-            } ?: "API_KEY_FROM_local.properties"
-        val weatherapiApiKey: String =
-            project.rootProject.file("local.properties").takeIf { it.exists() }?.inputStream()?.use {
-                Properties().apply { load(it) }.getProperty("WEATHERAPI_API_KEY")
-            } ?: "API_KEY_FROM_local.properties"
+        val localProperties = project.rootProject.file("local.properties").takeIf { it.exists() }?.inputStream()?.use {
+            Properties().apply { load(it) }
+        }
+
+        val openWeatherApiKey = localProperties?.getProperty("OPEN_WEATHER_API_KEY") ?: "MISSING-KEY"
+        val tomorrowIoApiKey = localProperties?.getProperty("TOMORROW_IO_API_KEY") ?: "MISSING-KEY"
+        val weatherapiApiKey = localProperties?.getProperty("WEATHERAPI_API_KEY") ?: "MISSING-KEY"
+
         buildConfigField("String", "OPEN_WEATHER_API_KEY", "\"$openWeatherApiKey\"")
         buildConfigField("String", "TOMORROW_IO_API_KEY", "\"$tomorrowIoApiKey\"")
         buildConfigField("String", "WEATHERAPI_API_KEY", "\"$weatherapiApiKey\"")


### PR DESCRIPTION
This pull request includes a refactor to the way API keys are read from the `local.properties` file in the `app/build.gradle.kts` file. The main change consolidates the reading of the properties file to reduce redundancy and improve code maintainability.

Improvements to code maintainability:

* [`app/build.gradle.kts`](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L51-R58): Consolidated the reading of the `local.properties` file into a single block, reducing redundancy and improving maintainability. Default values for missing keys are now set to `"MISSING-KEY"` instead of `"API_KEY_FROM_local.properties"`.