### PR TITLE
[FIX] Potential fix for post check - Refactored to use `java.time.Clock` for timestamp so that fixed time can be used in tests

### DIFF
--- a/data-model/src/main/java/dev/hossain/weatheralert/datamodel/WeatherApiServiceResponse.kt
+++ b/data-model/src/main/java/dev/hossain/weatheralert/datamodel/WeatherApiServiceResponse.kt
@@ -1,5 +1,7 @@
 package dev.hossain.weatheralert.datamodel
 
+import java.time.Clock
+
 /**
  * Marker interface for all weather API service response that must
  * provide converted [AppForecastData] using [convertToForecastData].
@@ -9,5 +11,5 @@ interface WeatherApiServiceResponse {
      * Converts the weather API service response to [AppForecastData] that is used
      * for caching and throughout the app.
      */
-    fun convertToForecastData(): AppForecastData
+    fun convertToForecastData(clock: Clock = Clock.systemDefaultZone()): AppForecastData
 }

--- a/service/openmeteo/src/main/java/com/openmeteo/api/model/OpenMeteoForecastResponse.kt
+++ b/service/openmeteo/src/main/java/com/openmeteo/api/model/OpenMeteoForecastResponse.kt
@@ -2,6 +2,7 @@ package com.openmeteo.api.model
 
 import dev.hossain.weatheralert.datamodel.AppForecastData
 import dev.hossain.weatheralert.datamodel.WeatherApiServiceResponse
+import java.time.Clock
 
 data class OpenMeteoForecastResponse(
     /**
@@ -9,5 +10,5 @@ data class OpenMeteoForecastResponse(
      */
     val appForecastData: AppForecastData,
 ) : WeatherApiServiceResponse {
-    override fun convertToForecastData(): AppForecastData = appForecastData
+    override fun convertToForecastData(clock: Clock): AppForecastData = appForecastData
 }

--- a/service/openweather/src/main/java/org/openweathermap/api/model/ApiModel.kt
+++ b/service/openweather/src/main/java/org/openweathermap/api/model/ApiModel.kt
@@ -4,6 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import dev.hossain.weatheralert.datamodel.AppForecastData
 import dev.hossain.weatheralert.datamodel.WeatherApiServiceResponse
+import java.time.Clock
 
 /**
  * Weather forecast data.
@@ -31,7 +32,7 @@ data class WeatherForecast(
     val hourly: List<HourlyForecast> = emptyList(),
     val daily: List<DailyForecast> = emptyList(),
 ) : WeatherApiServiceResponse {
-    override fun convertToForecastData(): AppForecastData = this.toForecastData()
+    override fun convertToForecastData(clock: Clock): AppForecastData = this.toForecastData()
 }
 
 @JsonClass(generateAdapter = true)

--- a/service/tomorrowio/src/main/java/io/tomorrow/api/model/TomorrowIo.kt
+++ b/service/tomorrowio/src/main/java/io/tomorrow/api/model/TomorrowIo.kt
@@ -4,6 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import dev.hossain.weatheralert.datamodel.AppForecastData
 import dev.hossain.weatheralert.datamodel.WeatherApiServiceResponse
+import java.time.Clock
 
 /**
  * Represents the main response from the Tomorrow.io API.
@@ -15,7 +16,7 @@ data class WeatherResponse(
     /** Timelines providing weather data across different intervals. */
     @Json(name = "timelines") val timelines: Timelines,
 ) : WeatherApiServiceResponse {
-    override fun convertToForecastData(): AppForecastData = this.toForecastData()
+    override fun convertToForecastData(clock: Clock): AppForecastData = this.toForecastData()
 }
 
 /**

--- a/service/weatherapi/src/main/java/com/weatherapi/api/model/Converter.kt
+++ b/service/weatherapi/src/main/java/com/weatherapi/api/model/Converter.kt
@@ -10,7 +10,12 @@ import java.time.ZoneId
 
 internal fun ForecastWeatherResponse.toForecastData(): AppForecastData {
     // Get current time millis in current time zone
-    val currentTimeMillis = Instant.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    val currentTimeMillis =
+        Instant
+            .now()
+            .atZone(ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli()
     val currentTimeSeconds = currentTimeMillis / 1000
 
     val hourlyPrecipitation =

--- a/service/weatherapi/src/main/java/com/weatherapi/api/model/Converter.kt
+++ b/service/weatherapi/src/main/java/com/weatherapi/api/model/Converter.kt
@@ -9,7 +9,10 @@ import java.time.Instant
 import java.time.ZoneId
 
 internal fun ForecastWeatherResponse.toForecastData(): AppForecastData {
-    val currentTimeSeconds = System.currentTimeMillis() / 1000
+    // Get current time millis in current time zone
+    val currentTimeMillis = Instant.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    val currentTimeSeconds = currentTimeMillis / 1000
+
     val hourlyPrecipitation =
         forecast.forecastDay.map { it.toHourlyPrecipitation(currentTimeSeconds) }.flatten()
     return AppForecastData(

--- a/service/weatherapi/src/main/java/com/weatherapi/api/model/Converter.kt
+++ b/service/weatherapi/src/main/java/com/weatherapi/api/model/Converter.kt
@@ -5,17 +5,13 @@ import dev.hossain.weatheralert.datamodel.CUMULATIVE_DATA_HOURS_24
 import dev.hossain.weatheralert.datamodel.HourlyPrecipitation
 import dev.hossain.weatheralert.datamodel.Rain
 import dev.hossain.weatheralert.datamodel.Snow
+import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 
-internal fun ForecastWeatherResponse.toForecastData(): AppForecastData {
+internal fun ForecastWeatherResponse.toForecastData(clock: Clock): AppForecastData {
     // Get current time millis in current time zone
-    val currentTimeMillis =
-        Instant
-            .now()
-            .atZone(ZoneId.systemDefault())
-            .toInstant()
-            .toEpochMilli()
+    val currentTimeMillis = getCurrentTimeMillis(clock)
     val currentTimeSeconds = currentTimeMillis / 1000
 
     val hourlyPrecipitation =
@@ -68,3 +64,11 @@ private fun Forecast.toRain(nextHourlyPrecipitation: List<HourlyPrecipitation>):
         weeklyCumulativeRain = 0.0,
     )
 }
+
+// Get current time millis in current time zone
+private fun getCurrentTimeMillis(clock: Clock): Long =
+    Instant
+        .now(clock)
+        .atZone(ZoneId.systemDefault())
+        .toInstant()
+        .toEpochMilli()

--- a/service/weatherapi/src/main/java/com/weatherapi/api/model/WeatherApi.kt
+++ b/service/weatherapi/src/main/java/com/weatherapi/api/model/WeatherApi.kt
@@ -4,6 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import dev.hossain.weatheralert.datamodel.AppForecastData
 import dev.hossain.weatheralert.datamodel.WeatherApiServiceResponse
+import java.time.Clock
 
 /**
  * Root response for WeatherAPI forecast request.
@@ -14,7 +15,7 @@ data class ForecastWeatherResponse(
     val current: Current,
     val forecast: Forecast,
 ) : WeatherApiServiceResponse {
-    override fun convertToForecastData(): AppForecastData = this.toForecastData()
+    override fun convertToForecastData(clock: Clock): AppForecastData = this.toForecastData(clock)
 }
 
 @JsonClass(generateAdapter = true)

--- a/service/weatherapi/src/test/java/com/weatherapi/api/WeatherApiResponseConverterTest.kt
+++ b/service/weatherapi/src/test/java/com/weatherapi/api/WeatherApiResponseConverterTest.kt
@@ -7,6 +7,9 @@ import dev.hossain.weatheralert.datamodel.AppForecastData
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 import java.util.TimeZone
 
 /**
@@ -15,10 +18,17 @@ import java.util.TimeZone
 class WeatherApiResponseConverterTest {
     private val originalTimeZone = TimeZone.getDefault()
 
+    private lateinit var fixedInstant: Instant
+    private lateinit var fixedClock: Clock
+
     @Before
     fun setUp() {
         // Set the default time zone to a specific time zone (e.g., "America/Toronto")
         TimeZone.setDefault(TimeZone.getTimeZone("America/Toronto"))
+
+        // Fixed instant time for testing
+        fixedInstant = Instant.parse("2025-02-01T10:00:00Z")
+        fixedClock = Clock.fixed(fixedInstant, ZoneId.systemDefault())
     }
 
     @After
@@ -31,7 +41,7 @@ class WeatherApiResponseConverterTest {
     fun convertsBuffaloWeatherResponseToAppForecastData() {
         val weatherResponse = loadWeatherResponseFromJson("weatherapi-buffalo-2025-02-05.json")
 
-        val result = weatherResponse.convertToForecastData()
+        val result = weatherResponse.convertToForecastData(fixedClock)
 
         assertThat(result.latitude).isEqualTo(42.8864)
         assertThat(result.longitude).isEqualTo(-78.8786)
@@ -47,14 +57,14 @@ class WeatherApiResponseConverterTest {
     fun convertsEdmontonWeatherResponseToAppForecastData() {
         val weatherResponse = loadWeatherResponseFromJson("weatherapi-edmonton-2025-02-05.json")
 
-        val result = weatherResponse.convertToForecastData()
+        val result = weatherResponse.convertToForecastData(fixedClock)
 
         assertThat(result.latitude).isEqualTo(53.55)
         assertThat(result.longitude).isEqualTo(-113.5)
-        assertThat(result.snow.dailyCumulativeSnow).isEqualTo(0.0)
+        assertThat(result.snow.dailyCumulativeSnow).isEqualTo(7.4)
         assertThat(result.snow.nextDaySnow).isEqualTo(0.0)
         assertThat(result.snow.weeklyCumulativeSnow).isEqualTo(0.0)
-        assertThat(result.rain.dailyCumulativeRain).isEqualTo(0.0)
+        assertThat(result.rain.dailyCumulativeRain).isEqualTo(1.02)
         assertThat(result.rain.nextDayRain).isEqualTo(0.0)
         assertThat(result.rain.weeklyCumulativeRain).isEqualTo(0.0)
     }
@@ -63,14 +73,14 @@ class WeatherApiResponseConverterTest {
     fun convertsMaringaWeatherResponseToAppForecastData() {
         val weatherResponse = loadWeatherResponseFromJson("weatherapi-maringa-brazil-2025-02-05-rain.json")
 
-        val result = weatherResponse.convertToForecastData()
+        val result = weatherResponse.convertToForecastData(fixedClock)
 
         assertThat(result.latitude).isEqualTo(-23.4167)
         assertThat(result.longitude).isEqualTo(-51.9167)
         assertThat(result.snow.dailyCumulativeSnow).isEqualTo(0.0)
         assertThat(result.snow.nextDaySnow).isEqualTo(0.0)
         assertThat(result.snow.weeklyCumulativeSnow).isEqualTo(0.0)
-        assertThat(result.rain.dailyCumulativeRain).isEqualTo(0.96)
+        assertThat(result.rain.dailyCumulativeRain).isEqualTo(29.14)
         assertThat(result.rain.nextDayRain).isEqualTo(50.09)
         assertThat(result.rain.weeklyCumulativeRain).isEqualTo(0.0)
     }
@@ -79,14 +89,14 @@ class WeatherApiResponseConverterTest {
     fun convertsUozoWeatherResponseToAppForecastData() {
         val weatherResponse = loadWeatherResponseFromJson("weatherapi-uozo-japan-2025-02-05-snow.json")
 
-        val result = weatherResponse.convertToForecastData()
+        val result = weatherResponse.convertToForecastData(fixedClock)
 
         assertThat(result.latitude).isEqualTo(36.8)
         assertThat(result.longitude).isEqualTo(137.4)
-        assertThat(result.snow.dailyCumulativeSnow).isEqualTo(122.80000000000001)
+        assertThat(result.snow.dailyCumulativeSnow).isEqualTo(107.10000000000001)
         assertThat(result.snow.nextDaySnow).isEqualTo(214.20000000000002)
         assertThat(result.snow.weeklyCumulativeSnow).isEqualTo(0.0)
-        assertThat(result.rain.dailyCumulativeRain).isEqualTo(31.350000000000005)
+        assertThat(result.rain.dailyCumulativeRain).isEqualTo(31.129999999999995)
         assertThat(result.rain.nextDayRain).isEqualTo(37.37)
         assertThat(result.rain.weeklyCumulativeRain).isEqualTo(0.0)
     }
@@ -95,17 +105,17 @@ class WeatherApiResponseConverterTest {
     fun convertsOshawaNotMuchSnowWeatherResponseToAppForecastData() {
         val weatherResponse = loadWeatherResponseFromJson("weatherapi-oshawa-2025-02-06-no-snow.json")
 
-        val result = weatherResponse.convertToForecastData()
+        val result = weatherResponse.convertToForecastData(fixedClock)
 
         assertThat(result.latitude).isEqualTo(43.9)
         assertThat(result.longitude).isEqualTo(-78.867)
-        assertThat(result.snow.dailyCumulativeSnow).isEqualTo(0.0)
+        assertThat(result.snow.dailyCumulativeSnow).isEqualTo(29.300000000000004)
         assertThat(result.snow.nextDaySnow).isEqualTo(0.0)
         assertThat(result.snow.weeklyCumulativeSnow).isEqualTo(0.0)
-        assertThat(result.rain.dailyCumulativeRain).isEqualTo(0.0)
+        assertThat(result.rain.dailyCumulativeRain).isEqualTo(4.0600000000000005)
         assertThat(result.rain.nextDayRain).isEqualTo(0.0)
         assertThat(result.rain.weeklyCumulativeRain).isEqualTo(0.0)
-        assertThat(result.hourlyPrecipitation).hasSize(25)
+        assertThat(result.hourlyPrecipitation).hasSize(48)
     }
 
     // Helper method to load WeatherResponse from JSON

--- a/service/weatherapi/src/test/java/com/weatherapi/api/WeatherApiResponseConverterTest.kt
+++ b/service/weatherapi/src/test/java/com/weatherapi/api/WeatherApiResponseConverterTest.kt
@@ -83,10 +83,10 @@ class WeatherApiResponseConverterTest {
 
         assertThat(result.latitude).isEqualTo(36.8)
         assertThat(result.longitude).isEqualTo(137.4)
-        assertThat(result.snow.dailyCumulativeSnow).isEqualTo(138.4)
+        assertThat(result.snow.dailyCumulativeSnow).isEqualTo(122.80000000000001)
         assertThat(result.snow.nextDaySnow).isEqualTo(214.20000000000002)
         assertThat(result.snow.weeklyCumulativeSnow).isEqualTo(0.0)
-        assertThat(result.rain.dailyCumulativeRain).isEqualTo(32.25000000000001)
+        assertThat(result.rain.dailyCumulativeRain).isEqualTo(31.350000000000005)
         assertThat(result.rain.nextDayRain).isEqualTo(37.37)
         assertThat(result.rain.weeklyCumulativeRain).isEqualTo(0.0)
     }
@@ -105,7 +105,7 @@ class WeatherApiResponseConverterTest {
         assertThat(result.rain.dailyCumulativeRain).isEqualTo(0.0)
         assertThat(result.rain.nextDayRain).isEqualTo(0.0)
         assertThat(result.rain.weeklyCumulativeRain).isEqualTo(0.0)
-        assertThat(result.hourlyPrecipitation).hasSize(26)
+        assertThat(result.hourlyPrecipitation).hasSize(25)
     }
 
     // Helper method to load WeatherResponse from JSON


### PR DESCRIPTION
Post check keeps failing - https://github.com/hossain-khan/android-weather-alert/actions/runs/13192303720/job/36828544170 for different values


```
> Task :service:weatherapi:testReleaseUnitTest

WeatherApiResponseConverterTest > convertsOshawaNotMuchSnowWeatherResponseToAppForecastData FAILED
    com.google.common.truth.ComparisonFailureWithFacts at WeatherApiResponseConverterTest.kt:108

WeatherApiResponseConverterTest > convertsUozoWeatherResponseToAppForecastData FAILED
    com.google.common.truth.ComparisonFailureWithFacts at WeatherApiResponseConverterTest.kt:86

9 tests completed, 2 failed

> Task :service:weatherapi:testReleaseUnitTest FAILED
gradle/actions: Writing build results to /home/runner/work/_temp/.gradle-actions/build-results/__run_2-1738899740227.json
```