### PR TITLE
[REFACTOR] Moved the `requiresApiKey` to service enum

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/ui/UiExtensions.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/UiExtensions.kt
@@ -37,11 +37,6 @@ data class WeatherServiceConfig(
      * Optional API service name that is required for the API key.
      */
     val apiServiceProductName: String,
-    /**
-     * Indicates API key is required to avoid rate limiting or overuse.
-     * Some services does not require API key or has high limit making it not required to provide API key.
-     */
-    val requiresApiKey: Boolean,
 )
 
 internal fun WeatherForecastService.serviceConfig(): WeatherServiceConfig =
@@ -60,7 +55,6 @@ internal fun WeatherForecastService.serviceConfig(): WeatherServiceConfig =
                         "To continue to use this app, you need to provide your own API key from OpenWeatherMap.",
                 apiFormatGuide = "API key should be 32 characters long and contain only hexadecimal characters.",
                 apiServiceProductName = "One Call API 3.0",
-                requiresApiKey = true,
             )
         WeatherForecastService.TOMORROW_IO ->
             WeatherServiceConfig(
@@ -76,7 +70,6 @@ internal fun WeatherForecastService.serviceConfig(): WeatherServiceConfig =
                         "To continue to use this app, you need to provide your own API key from Tomorrow.io.",
                 apiFormatGuide = "API key should be 32 characters long and contain only letters and numbers.",
                 apiServiceProductName = "Weather API",
-                requiresApiKey = true,
             )
 
         WeatherForecastService.OPEN_METEO ->
@@ -91,7 +84,6 @@ internal fun WeatherForecastService.serviceConfig(): WeatherServiceConfig =
                 apiExhaustedMessage = "Not applicable for Open-Meteo API.",
                 apiFormatGuide = "Not applicable.",
                 apiServiceProductName = "Weather API",
-                requiresApiKey = false,
             )
 
         WeatherForecastService.WEATHER_API ->
@@ -107,6 +99,5 @@ internal fun WeatherForecastService.serviceConfig(): WeatherServiceConfig =
                 apiExhaustedMessage = "Not applicable for WeatherAPI.",
                 apiFormatGuide = "Not applicable.",
                 apiServiceProductName = "WeatherAPI",
-                requiresApiKey = false,
             )
     }

--- a/app/src/main/java/dev/hossain/weatheralert/ui/settings/UserSettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/settings/UserSettingsScreen.kt
@@ -234,7 +234,7 @@ fun UserSettingsScreen(
 
             AddServiceApiKeyUi(
                 selectedService = state.selectedService,
-                isServiceApiKeyRequired = state.selectedService.serviceConfig().requiresApiKey,
+                isServiceApiKeyRequired = state.selectedService.requiresApiKey,
                 isUserProvidedApiKeyInUse = state.isUserProvidedApiKeyInUse,
                 eventSink = state.eventSink,
             )

--- a/data-model/src/main/java/dev/hossain/weatheralert/datamodel/WeatherForecastService.kt
+++ b/data-model/src/main/java/dev/hossain/weatheralert/datamodel/WeatherForecastService.kt
@@ -8,6 +8,11 @@ import androidx.annotation.Keep
 @Keep
 enum class WeatherForecastService(
     /**
+     * Indicates API key is required to avoid rate limiting or overuse.
+     * Some services does not require API key or has high limit making it not required to provide API key.
+     */
+    val requiresApiKey: Boolean = false,
+    /**
      * Indicates if the weather forecast service is enabled or disabled at build time.
      */
     val isEnabled: Boolean = true,
@@ -16,13 +21,19 @@ enum class WeatherForecastService(
      * OpenWeatherMap API for weather forecast.
      * - https://openweathermap.org/api
      */
-    OPEN_WEATHER_MAP,
+    OPEN_WEATHER_MAP(
+        // See limits at https://github.com/hossain-khan/android-weather-alert/tree/main/service#weather-services
+        requiresApiKey = true,
+    ),
 
     /**
      * Tomorrow.io API for weather forecast.
      * - https://app.tomorrow.io/home
      */
-    TOMORROW_IO,
+    TOMORROW_IO(
+        // See limits at https://github.com/hossain-khan/android-weather-alert/tree/main/service#weather-services
+        requiresApiKey = true,
+    ),
 
     /**
      * Open-Meteo API for weather forecast.


### PR DESCRIPTION
This pull request includes changes to refactor how the `requiresApiKey` property is managed within the `WeatherForecastService` class and its usage across the codebase. The main goal is to simplify the handling of API key requirements by moving the `requiresApiKey` property directly into the `WeatherForecastService` enum.

Refactoring API key requirement handling:

* [`data-model/src/main/java/dev/hossain/weatheralert/datamodel/WeatherForecastService.kt`](diffhunk://#diff-97b5fbdb586f990a01895d7a5e9da4ddb75d3365a809be04ab51b5d39fa86157R10-R14): Added `requiresApiKey` property to the `WeatherForecastService` enum and set default values for each service. [[1]](diffhunk://#diff-97b5fbdb586f990a01895d7a5e9da4ddb75d3365a809be04ab51b5d39fa86157R10-R14) [[2]](diffhunk://#diff-97b5fbdb586f990a01895d7a5e9da4ddb75d3365a809be04ab51b5d39fa86157L19-R36)
* [`app/src/main/java/dev/hossain/weatheralert/ui/UiExtensions.kt`](diffhunk://#diff-4b4067ae596aad6b6ddf471c2c66377d730e76f6508c1416655a208ebe475e09L40-L44): Removed the `requiresApiKey` property from `WeatherServiceConfig` data class and updated the `serviceConfig` function to reflect this change. [[1]](diffhunk://#diff-4b4067ae596aad6b6ddf471c2c66377d730e76f6508c1416655a208ebe475e09L40-L44) [[2]](diffhunk://#diff-4b4067ae596aad6b6ddf471c2c66377d730e76f6508c1416655a208ebe475e09L63) [[3]](diffhunk://#diff-4b4067ae596aad6b6ddf471c2c66377d730e76f6508c1416655a208ebe475e09L79) [[4]](diffhunk://#diff-4b4067ae596aad6b6ddf471c2c66377d730e76f6508c1416655a208ebe475e09L94) [[5]](diffhunk://#diff-4b4067ae596aad6b6ddf471c2c66377d730e76f6508c1416655a208ebe475e09L110)
* [`app/src/main/java/dev/hossain/weatheralert/ui/settings/UserSettingsScreen.kt`](diffhunk://#diff-ec663cff353f821ff981286e15fb767064ae30c617d2b17bb8752428e3dded97L237-R237): Updated the `UserSettingsScreen` function to use the new `requiresApiKey` property from `WeatherForecastService`.