### PR TITLE
327 inject forecast response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ google-services.json
 app/debug/*
 app/release/*
 *.salive
+
+# Weather Alert Project Files
+test_*.json

--- a/app/src/main/java/dev/hossain/weatheralert/di/NetworkModule.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/di/NetworkModule.kt
@@ -51,6 +51,8 @@ object NetworkModule {
         return OkHttpClient
             .Builder()
             .cache(cache)
+            // Added to simulate and test with static forecast response
+            // .addInterceptor(SimulatedResponseInterceptor(context))
             .addInterceptor(loggingInterceptor)
             .build()
     }

--- a/app/src/main/java/dev/hossain/weatheralert/simulation/SimulatedResponseInterceptor.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/simulation/SimulatedResponseInterceptor.kt
@@ -1,0 +1,59 @@
+package dev.hossain.weatheralert.simulation
+
+import android.content.Context
+import dev.hossain.weatheralert.R
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import timber.log.Timber
+import java.io.InputStreamReader
+
+/**
+ * An OkHttp Interceptor that simulates responses for specific API requests by providing
+ * JSON responses from raw resources based on the request URL.
+ */
+class SimulatedResponseInterceptor(
+    private val context: Context,
+) : Interceptor {
+    /**
+     * Intercepts the HTTP request and provides a simulated response if the request URL matches
+     * one of the predefined patterns. Otherwise, proceeds with the actual request.
+     */
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val url = request.url.toString()
+
+        // Determine the appropriate response based on the request URL.
+        val responseString =
+            when {
+                url.contains("api.openweathermap.org") -> readRawResource(R.raw.simulated_forecast_response)
+                url.contains("api.tomorrow.io") -> readRawResource(R.raw.simulated_forecast_response)
+                url.contains("api.weatherapi.com") -> readRawResource(R.raw.simulated_forecast_response)
+                else -> null
+            }
+
+        // If a simulated response is found, return it. Otherwise, proceed with the actual request.
+        return if (responseString != null) {
+            Timber.i("🤖 Sending simulated response for: $url")
+            Response
+                .Builder()
+                .request(request)
+                .protocol(chain.connection()?.protocol() ?: okhttp3.Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(responseString.toResponseBody("application/json".toMediaTypeOrNull()))
+                .build()
+        } else {
+            chain.proceed(request)
+        }
+    }
+
+    /**
+     * Reads the content of a raw resource file and returns it as a string.
+     */
+    private fun readRawResource(resourceId: Int): String {
+        val inputStream = context.resources.openRawResource(resourceId)
+        return InputStreamReader(inputStream).use { it.readText() }
+    }
+}

--- a/app/src/main/res/raw/keep_me_in_raw
+++ b/app/src/main/res/raw/keep_me_in_raw
@@ -1,0 +1,1 @@
+Some JSON raw file will be put here.

--- a/app/src/main/res/raw/simulated_forecast_response.json
+++ b/app/src/main/res/raw/simulated_forecast_response.json
@@ -1,0 +1,3 @@
+{
+  "description": "A fake forecast response"
+}


### PR DESCRIPTION
This pull request introduces a new feature to simulate API responses for testing purposes. The most important changes include adding a new interceptor class, updating the network module to optionally include this interceptor, and adding necessary resource files.

New feature for simulating API responses:

* [`app/src/main/java/dev/hossain/weatheralert/simulation/SimulatedResponseInterceptor.kt`](diffhunk://#diff-236b4fc3c618e57066147eb712a660dc1a615d7068800c6a9a659ca0304096c7R1-R59): Added a new interceptor class `SimulatedResponseInterceptor` that provides simulated JSON responses for specific API requests based on the request URL.

Updates to network module:

* [`app/src/main/java/dev/hossain/weatheralert/di/NetworkModule.kt`](diffhunk://#diff-37196024d7b0cdb035084d6a7f118f76ff170895ba4d96626ebedc81306c231cR54-R55): Updated the network module to include a commented-out line for adding the `SimulatedResponseInterceptor` for testing purposes.

New resource files:

* [`app/src/main/res/raw/simulated_forecast_response.json`](diffhunk://#diff-a0bc57e992b253d23c0adf02cb9261fe7d5bcf1a8f3a3fbf3c4232c15b5397beR1-R3): Added a new JSON file to provide a fake forecast response for simulation.
* [`app/src/main/res/raw/keep_me_in_raw`](diffhunk://#diff-3aca561b3504bfd1c82fc6677ef09fae1dc43e296b0aa8c321e04fac33264ecaR1): Added a placeholder file indicating that JSON raw files will be added here.