### PR TITLE
[FIXED] Bug where more than 24 hours were counted for snow

### DIFF
--- a/app/src/test/java/dev/hossain/weatheralert/data/WeatherRepositoryTest.kt
+++ b/app/src/test/java/dev/hossain/weatheralert/data/WeatherRepositoryTest.kt
@@ -251,7 +251,7 @@ class WeatherRepositoryTest {
             val forecast: AppForecastData = (result as ApiResult.Success).value
             assertThat(forecast.latitude).isEqualTo(38.4685)
             assertThat(forecast.longitude).isEqualTo(-100.9596)
-            assertThat(forecast.snow.dailyCumulativeSnow).isEqualTo(12.499999999999998)
+            assertThat(forecast.snow.dailyCumulativeSnow).isEqualTo(10.999999999999998)
         }
 
     @Test
@@ -274,7 +274,7 @@ class WeatherRepositoryTest {
             val forecast: AppForecastData = (result as ApiResult.Success).value
             assertThat(forecast.latitude).isEqualTo(38.6289)
             assertThat(forecast.longitude).isEqualTo(-90.2546)
-            assertThat(forecast.snow.dailyCumulativeSnow).isEqualTo(272.3)
+            assertThat(forecast.snow.dailyCumulativeSnow).isEqualTo(271.3)
         }
 
     @Test
@@ -320,7 +320,7 @@ class WeatherRepositoryTest {
             val forecast: AppForecastData = (result as ApiResult.Success).value
             assertThat(forecast.latitude).isEqualTo(50.7756)
             assertThat(forecast.longitude).isEqualTo(6.0836)
-            assertThat(forecast.snow.dailyCumulativeSnow).isEqualTo(202.49999999999997)
+            assertThat(forecast.snow.dailyCumulativeSnow).isEqualTo(200.09999999999997)
             assertThat(forecast.snow.nextDaySnow).isEqualTo(20.01)
             assertThat(forecast.rain.dailyCumulativeRain).isEqualTo(5.9)
             assertThat(forecast.rain.nextDayRain).isEqualTo(5.9)

--- a/service/openweather/src/main/java/org/openweathermap/api/model/Converter.kt
+++ b/service/openweather/src/main/java/org/openweathermap/api/model/Converter.kt
@@ -22,6 +22,7 @@ internal fun WeatherForecast.toForecastData(): AppForecastData =
             Snow(
                 dailyCumulativeSnow =
                     hourly
+                        .take(CUMULATIVE_DATA_HOURS_24)
                         .sumOf { it.snow?.snowVolumeInAnHour ?: 0.0 } * 10,
                 nextDaySnow =
                     daily

--- a/service/openweather/src/test/java/org/openweathermap/api/WeatherForecastConverterTest.kt
+++ b/service/openweather/src/test/java/org/openweathermap/api/WeatherForecastConverterTest.kt
@@ -36,7 +36,7 @@ class WeatherForecastConverterTest {
 
         assertThat(result.latitude).isEqualTo(43.9319)
         assertThat(result.longitude).isEqualTo(-78.851)
-        assertThat(result.snow.dailyCumulativeSnow).isEqualTo(40.300000000000004)
+        assertThat(result.snow.dailyCumulativeSnow).isEqualTo(38.7)
         assertThat(result.snow.nextDaySnow).isEqualTo(2.06)
         assertThat(result.snow.weeklyCumulativeSnow).isEqualTo(0.0)
         assertThat(result.rain.dailyCumulativeRain).isEqualTo(0.0)

--- a/service/openweather/src/test/java/org/openweathermap/api/WeatherForecastConverterTest.kt
+++ b/service/openweather/src/test/java/org/openweathermap/api/WeatherForecastConverterTest.kt
@@ -93,6 +93,22 @@ class WeatherForecastConverterTest {
         assertThat(result.rain.weeklyCumulativeRain).isEqualTo(0.0)
     }
 
+    @Test
+    fun `given light snow on oshawa city further out - does not show snow in next 24 hours`() {
+        val weatherForecast = loadWeatherForecastFromJson("open-weather-oshawa-2025-02-25-light-snow.json")
+
+        val result = weatherForecast.convertToForecastData()
+
+        assertThat(result.latitude).isEqualTo(43.9)
+        assertThat(result.longitude).isEqualTo(-78.85)
+        assertThat(result.snow.dailyCumulativeSnow).isEqualTo(0.0)
+        assertThat(result.snow.nextDaySnow).isEqualTo(0.0)
+        assertThat(result.snow.weeklyCumulativeSnow).isEqualTo(0.0)
+        assertThat(result.rain.dailyCumulativeRain).isEqualTo(0.87)
+        assertThat(result.rain.nextDayRain).isEqualTo(0.87)
+        assertThat(result.rain.weeklyCumulativeRain).isEqualTo(0.0)
+    }
+
     // Helper method to load WeatherForecast from JSON
     private fun loadWeatherForecastFromJson(fileName: String): WeatherApiServiceResponse {
         val classLoader = javaClass.classLoader

--- a/service/openweather/src/test/resources/open-weather-oshawa-2025-02-25-light-snow.json
+++ b/service/openweather/src/test/resources/open-weather-oshawa-2025-02-25-light-snow.json
@@ -1,0 +1,1481 @@
+{
+  "lat": 43.9,
+  "lon": -78.85,
+  "timezone": "America/Toronto",
+  "timezone_offset": -18000,
+  "hourly": [
+    {
+      "dt": 1740520800,
+      "temp": 3.13,
+      "feels_like": 0.28,
+      "pressure": 1007,
+      "humidity": 89,
+      "dew_point": 1.5,
+      "uvi": 0.08,
+      "clouds": 100,
+      "wind_speed": 2.97,
+      "wind_deg": 278,
+      "wind_gust": 6.2,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740524400,
+      "temp": 3.37,
+      "feels_like": 0.77,
+      "pressure": 1007,
+      "humidity": 86,
+      "dew_point": 1.25,
+      "uvi": 0,
+      "clouds": 100,
+      "wind_speed": 2.73,
+      "wind_deg": 274,
+      "wind_gust": 6.18,
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10n"
+        }
+      ],
+      "pop": 0.2,
+      "rain": {
+        "1h": 0.87
+      }
+    },
+    {
+      "dt": 1740528000,
+      "temp": 3.09,
+      "feels_like": -0.36,
+      "pressure": 1007,
+      "humidity": 88,
+      "dew_point": 1.3,
+      "uvi": 0,
+      "clouds": 100,
+      "wind_speed": 3.8,
+      "wind_deg": 289,
+      "wind_gust": 7.37,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740531600,
+      "temp": 2.73,
+      "feels_like": -0.55,
+      "pressure": 1008,
+      "humidity": 90,
+      "dew_point": 1.26,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 7500,
+      "wind_speed": 3.44,
+      "wind_deg": 298,
+      "wind_gust": 7.31,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740535200,
+      "temp": 2.36,
+      "feels_like": -1.21,
+      "pressure": 1008,
+      "humidity": 92,
+      "dew_point": 1.2,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 3.74,
+      "wind_deg": 291,
+      "wind_gust": 8.58,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740538800,
+      "temp": 1.79,
+      "feels_like": -1.89,
+      "pressure": 1009,
+      "humidity": 91,
+      "dew_point": 0.48,
+      "uvi": 0,
+      "clouds": 99,
+      "visibility": 10000,
+      "wind_speed": 3.71,
+      "wind_deg": 286,
+      "wind_gust": 8.97,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740542400,
+      "temp": 1.89,
+      "feels_like": -1.86,
+      "pressure": 1010,
+      "humidity": 85,
+      "dew_point": -0.61,
+      "uvi": 0,
+      "clouds": 99,
+      "visibility": 10000,
+      "wind_speed": 3.85,
+      "wind_deg": 278,
+      "wind_gust": 8.36,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740546000,
+      "temp": 1.04,
+      "feels_like": -3.28,
+      "pressure": 1010,
+      "humidity": 88,
+      "dew_point": -1.04,
+      "uvi": 0,
+      "clouds": 95,
+      "visibility": 10000,
+      "wind_speed": 4.42,
+      "wind_deg": 293,
+      "wind_gust": 8.72,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740549600,
+      "temp": 0.82,
+      "feels_like": -4.13,
+      "pressure": 1011,
+      "humidity": 88,
+      "dew_point": -1.11,
+      "uvi": 0,
+      "clouds": 96,
+      "visibility": 10000,
+      "wind_speed": 5.44,
+      "wind_deg": 312,
+      "wind_gust": 9.66,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740553200,
+      "temp": 0.6,
+      "feels_like": -4.05,
+      "pressure": 1011,
+      "humidity": 87,
+      "dew_point": -1.57,
+      "uvi": 0,
+      "clouds": 96,
+      "visibility": 10000,
+      "wind_speed": 4.8,
+      "wind_deg": 321,
+      "wind_gust": 9.58,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740556800,
+      "temp": 0.62,
+      "feels_like": -3.73,
+      "pressure": 1011,
+      "humidity": 85,
+      "dew_point": -1.92,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 4.32,
+      "wind_deg": 318,
+      "wind_gust": 9.15,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740560400,
+      "temp": 0.58,
+      "feels_like": -3.8,
+      "pressure": 1012,
+      "humidity": 82,
+      "dew_point": -2.31,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 4.35,
+      "wind_deg": 317,
+      "wind_gust": 8.68,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740564000,
+      "temp": 0.46,
+      "feels_like": -3.34,
+      "pressure": 1012,
+      "humidity": 82,
+      "dew_point": -2.52,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 3.48,
+      "wind_deg": 324,
+      "wind_gust": 7.95,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740567600,
+      "temp": 0.18,
+      "feels_like": -2.3,
+      "pressure": 1013,
+      "humidity": 85,
+      "dew_point": -2.36,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 2.04,
+      "wind_deg": 303,
+      "wind_gust": 4.8,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740571200,
+      "temp": -0.24,
+      "feels_like": -3.41,
+      "pressure": 1013,
+      "humidity": 89,
+      "dew_point": -2.19,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 2.6,
+      "wind_deg": 274,
+      "wind_gust": 5.33,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740574800,
+      "temp": 0.3,
+      "feels_like": -2.84,
+      "pressure": 1014,
+      "humidity": 90,
+      "dew_point": -1.36,
+      "uvi": 0.33,
+      "clouds": 99,
+      "visibility": 10000,
+      "wind_speed": 2.67,
+      "wind_deg": 297,
+      "wind_gust": 6.73,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740578400,
+      "temp": 0.82,
+      "feels_like": -1.86,
+      "pressure": 1014,
+      "humidity": 88,
+      "dew_point": -1.27,
+      "uvi": 0.87,
+      "clouds": 99,
+      "visibility": 10000,
+      "wind_speed": 2.32,
+      "wind_deg": 314,
+      "wind_gust": 4.93,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740582000,
+      "temp": 1.07,
+      "feels_like": -1.11,
+      "pressure": 1014,
+      "humidity": 92,
+      "dew_point": -0.48,
+      "uvi": 2.01,
+      "clouds": 89,
+      "visibility": 10000,
+      "wind_speed": 1.92,
+      "wind_deg": 288,
+      "wind_gust": 4.06,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740585600,
+      "temp": 1.37,
+      "feels_like": -1.74,
+      "pressure": 1015,
+      "humidity": 92,
+      "dew_point": -0.15,
+      "uvi": 2.81,
+      "clouds": 91,
+      "visibility": 9425,
+      "wind_speed": 2.87,
+      "wind_deg": 260,
+      "wind_gust": 5.12,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740589200,
+      "temp": 1.42,
+      "feels_like": -1.56,
+      "pressure": 1015,
+      "humidity": 92,
+      "dew_point": -0.08,
+      "uvi": 2.78,
+      "clouds": 93,
+      "visibility": 9610,
+      "wind_speed": 2.73,
+      "wind_deg": 266,
+      "wind_gust": 5.41,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740592800,
+      "temp": 1.64,
+      "feels_like": 0.01,
+      "pressure": 1014,
+      "humidity": 92,
+      "dew_point": 0.21,
+      "uvi": 2.31,
+      "clouds": 94,
+      "visibility": 9979,
+      "wind_speed": 1.57,
+      "wind_deg": 257,
+      "wind_gust": 3.07,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740596400,
+      "temp": 1.5,
+      "feels_like": -0.36,
+      "pressure": 1013,
+      "humidity": 91,
+      "dew_point": -0.18,
+      "uvi": 1.34,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 1.72,
+      "wind_deg": 214,
+      "wind_gust": 3.47,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740600000,
+      "temp": 1.32,
+      "feels_like": -0.8,
+      "pressure": 1013,
+      "humidity": 92,
+      "dew_point": -0.22,
+      "uvi": 1.08,
+      "clouds": 100,
+      "visibility": 9999,
+      "wind_speed": 1.9,
+      "wind_deg": 196,
+      "wind_gust": 2.26,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740603600,
+      "temp": 1.24,
+      "feels_like": -0.81,
+      "pressure": 1013,
+      "humidity": 93,
+      "dew_point": -0.15,
+      "uvi": 0.46,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 1.84,
+      "wind_deg": 209,
+      "wind_gust": 2.8,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740607200,
+      "temp": 1.07,
+      "feels_like": -0.33,
+      "pressure": 1013,
+      "humidity": 94,
+      "dew_point": -0.15,
+      "uvi": 0.11,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 1.37,
+      "wind_deg": 192,
+      "wind_gust": 1.76,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740610800,
+      "temp": 0.37,
+      "feels_like": 0.37,
+      "pressure": 1014,
+      "humidity": 94,
+      "dew_point": -0.78,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 7995,
+      "wind_speed": 1.28,
+      "wind_deg": 185,
+      "wind_gust": 1.98,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740614400,
+      "temp": 0.48,
+      "feels_like": 0.48,
+      "pressure": 1013,
+      "humidity": 94,
+      "dew_point": -0.66,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 0.93,
+      "wind_deg": 99,
+      "wind_gust": 1.57,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740618000,
+      "temp": 0.37,
+      "feels_like": 0.37,
+      "pressure": 1013,
+      "humidity": 96,
+      "dew_point": -0.5,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 7018,
+      "wind_speed": 1.06,
+      "wind_deg": 100,
+      "wind_gust": 2.06,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740621600,
+      "temp": 0.33,
+      "feels_like": -2.08,
+      "pressure": 1013,
+      "humidity": 98,
+      "dew_point": -0.26,
+      "uvi": 0,
+      "clouds": 100,
+      "wind_speed": 2.01,
+      "wind_deg": 82,
+      "wind_gust": 2.95,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740625200,
+      "temp": 0.32,
+      "feels_like": -2.85,
+      "pressure": 1012,
+      "humidity": 98,
+      "dew_point": -0.21,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 1297,
+      "wind_speed": 2.71,
+      "wind_deg": 82,
+      "wind_gust": 4.39,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740628800,
+      "temp": 0.45,
+      "feels_like": -3.48,
+      "pressure": 1011,
+      "humidity": 98,
+      "dew_point": -0.05,
+      "uvi": 0,
+      "clouds": 100,
+      "wind_speed": 3.65,
+      "wind_deg": 78,
+      "wind_gust": 5.9,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04n"
+        }
+      ],
+      "pop": 0
+    },
+    {
+      "dt": 1740632400,
+      "temp": 0.39,
+      "feels_like": -3.92,
+      "pressure": 1010,
+      "humidity": 99,
+      "dew_point": -0.03,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 85,
+      "wind_speed": 4.17,
+      "wind_deg": 86,
+      "wind_gust": 7.14,
+      "weather": [
+        {
+          "id": 600,
+          "main": "Snow",
+          "description": "light snow",
+          "icon": "13n"
+        }
+      ],
+      "pop": 0.2,
+      "snow": {
+        "1h": 0.12
+      }
+    },
+    {
+      "dt": 1740636000,
+      "temp": 0.3,
+      "feels_like": -4.65,
+      "pressure": 1009,
+      "humidity": 99,
+      "dew_point": -0.05,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 35,
+      "wind_speed": 5.2,
+      "wind_deg": 81,
+      "wind_gust": 8.83,
+      "weather": [
+        {
+          "id": 600,
+          "main": "Snow",
+          "description": "light snow",
+          "icon": "13n"
+        }
+      ],
+      "pop": 0.2,
+      "snow": {
+        "1h": 0.12
+      }
+    },
+    {
+      "dt": 1740639600,
+      "temp": 0.62,
+      "feels_like": -4.5,
+      "pressure": 1008,
+      "humidity": 99,
+      "dew_point": 0.16,
+      "uvi": 0,
+      "clouds": 100,
+      "wind_speed": 5.68,
+      "wind_deg": 78,
+      "wind_gust": 9.5,
+      "weather": [
+        {
+          "id": 600,
+          "main": "Snow",
+          "description": "light snow",
+          "icon": "13n"
+        }
+      ],
+      "pop": 0.98,
+      "snow": {
+        "1h": 0.15
+      }
+    },
+    {
+      "dt": 1740643200,
+      "temp": 0.68,
+      "feels_like": -4.57,
+      "pressure": 1006,
+      "humidity": 99,
+      "dew_point": 0.25,
+      "uvi": 0,
+      "clouds": 100,
+      "wind_speed": 5.96,
+      "wind_deg": 74,
+      "wind_gust": 10.21,
+      "weather": [
+        {
+          "id": 600,
+          "main": "Snow",
+          "description": "light snow",
+          "icon": "13n"
+        }
+      ],
+      "pop": 1,
+      "snow": {
+        "1h": 0.24
+      }
+    },
+    {
+      "dt": 1740646800,
+      "temp": 0.46,
+      "feels_like": -4.83,
+      "pressure": 1005,
+      "humidity": 99,
+      "dew_point": 0.01,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 188,
+      "wind_speed": 5.93,
+      "wind_deg": 70,
+      "wind_gust": 10.82,
+      "weather": [
+        {
+          "id": 600,
+          "main": "Snow",
+          "description": "light snow",
+          "icon": "13n"
+        }
+      ],
+      "pop": 1,
+      "snow": {
+        "1h": 0.35
+      }
+    },
+    {
+      "dt": 1740650400,
+      "temp": 0.2,
+      "feels_like": -5.56,
+      "pressure": 1004,
+      "humidity": 99,
+      "dew_point": -0.26,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 235,
+      "wind_speed": 6.78,
+      "wind_deg": 70,
+      "wind_gust": 12.01,
+      "weather": [
+        {
+          "id": 600,
+          "main": "Snow",
+          "description": "light snow",
+          "icon": "13n"
+        }
+      ],
+      "pop": 1,
+      "snow": {
+        "1h": 0.43
+      }
+    },
+    {
+      "dt": 1740654000,
+      "temp": -0.07,
+      "feels_like": -5.51,
+      "pressure": 1003,
+      "humidity": 99,
+      "dew_point": -0.52,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 103,
+      "wind_speed": 5.94,
+      "wind_deg": 68,
+      "wind_gust": 10.72,
+      "weather": [
+        {
+          "id": 601,
+          "main": "Snow",
+          "description": "snow",
+          "icon": "13n"
+        }
+      ],
+      "pop": 1,
+      "snow": {
+        "1h": 2.84
+      }
+    },
+    {
+      "dt": 1740657600,
+      "temp": -0.21,
+      "feels_like": -5.6,
+      "pressure": 1003,
+      "humidity": 97,
+      "dew_point": -0.84,
+      "uvi": 0,
+      "clouds": 100,
+      "visibility": 283,
+      "wind_speed": 5.77,
+      "wind_deg": 60,
+      "wind_gust": 9.8,
+      "weather": [
+        {
+          "id": 601,
+          "main": "Snow",
+          "description": "snow",
+          "icon": "13d"
+        }
+      ],
+      "pop": 1,
+      "snow": {
+        "1h": 1.29
+      }
+    },
+    {
+      "dt": 1740661200,
+      "temp": -0.27,
+      "feels_like": -5.37,
+      "pressure": 1003,
+      "humidity": 95,
+      "dew_point": -1.22,
+      "uvi": 0.12,
+      "clouds": 100,
+      "visibility": 8364,
+      "wind_speed": 5.2,
+      "wind_deg": 63,
+      "wind_gust": 8.02,
+      "weather": [
+        {
+          "id": 600,
+          "main": "Snow",
+          "description": "light snow",
+          "icon": "13d"
+        }
+      ],
+      "pop": 0.67,
+      "snow": {
+        "1h": 0.16
+      }
+    },
+    {
+      "dt": 1740664800,
+      "temp": -0.36,
+      "feels_like": -5.26,
+      "pressure": 1002,
+      "humidity": 94,
+      "dew_point": -1.54,
+      "uvi": 0.24,
+      "clouds": 100,
+      "visibility": 10000,
+      "wind_speed": 4.82,
+      "wind_deg": 47,
+      "wind_gust": 7.05,
+      "weather": [
+        {
+          "id": 600,
+          "main": "Snow",
+          "description": "light snow",
+          "icon": "13d"
+        }
+      ],
+      "pop": 0.58,
+      "snow": {
+        "1h": 0.15
+      }
+    },
+    {
+      "dt": 1740668400,
+      "temp": -0.29,
+      "feels_like": -4.44,
+      "pressure": 1001,
+      "humidity": 94,
+      "dew_point": -1.38,
+      "uvi": 0.47,
+      "clouds": 100,
+      "visibility": 9757,
+      "wind_speed": 3.73,
+      "wind_deg": 50,
+      "wind_gust": 5.33,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0.54
+    },
+    {
+      "dt": 1740672000,
+      "temp": 0,
+      "feels_like": -2.97,
+      "pressure": 1001,
+      "humidity": 95,
+      "dew_point": -1.03,
+      "uvi": 0.82,
+      "clouds": 100,
+      "visibility": 9664,
+      "wind_speed": 2.45,
+      "wind_deg": 37,
+      "wind_gust": 3.1,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "pop": 0.55
+    },
+    {
+      "dt": 1740675600,
+      "temp": 0.01,
+      "feels_like": 0.01,
+      "pressure": 1001,
+      "humidity": 97,
+      "dew_point": -0.71,
+      "uvi": 0.84,
+      "clouds": 100,
+      "visibility": 1975,
+      "wind_speed": 0.98,
+      "wind_deg": 22,
+      "wind_gust": 1.29,
+      "weather": [
+        {
+          "id": 600,
+          "main": "Snow",
+          "description": "light snow",
+          "icon": "13d"
+        }
+      ],
+      "pop": 1,
+      "snow": {
+        "1h": 0.14
+      }
+    },
+    {
+      "dt": 1740679200,
+      "temp": 0.06,
+      "feels_like": -1.59,
+      "pressure": 1000,
+      "humidity": 99,
+      "dew_point": -0.35,
+      "uvi": 0.65,
+      "clouds": 100,
+      "visibility": 119,
+      "wind_speed": 1.44,
+      "wind_deg": 288,
+      "wind_gust": 1.97,
+      "weather": [
+        {
+          "id": 601,
+          "main": "Snow",
+          "description": "snow",
+          "icon": "13d"
+        }
+      ],
+      "pop": 1,
+      "snow": {
+        "1h": 0.55
+      }
+    },
+    {
+      "dt": 1740682800,
+      "temp": 0.58,
+      "feels_like": -3.25,
+      "pressure": 1000,
+      "humidity": 100,
+      "dew_point": 0.25,
+      "uvi": 1.13,
+      "clouds": 100,
+      "visibility": 55,
+      "wind_speed": 3.55,
+      "wind_deg": 258,
+      "wind_gust": 4.98,
+      "weather": [
+        {
+          "id": 601,
+          "main": "Snow",
+          "description": "snow",
+          "icon": "13d"
+        }
+      ],
+      "pop": 1,
+      "snow": {
+        "1h": 0.58
+      }
+    },
+    {
+      "dt": 1740686400,
+      "temp": 0.81,
+      "feels_like": -3.68,
+      "pressure": 1000,
+      "humidity": 100,
+      "dew_point": 0.46,
+      "uvi": 0.68,
+      "clouds": 100,
+      "visibility": 56,
+      "wind_speed": 4.61,
+      "wind_deg": 277,
+      "wind_gust": 7.99,
+      "weather": [
+        {
+          "id": 601,
+          "main": "Snow",
+          "description": "snow",
+          "icon": "13d"
+        }
+      ],
+      "pop": 1,
+      "snow": {
+        "1h": 0.84
+      }
+    },
+    {
+      "dt": 1740690000,
+      "temp": 1.1,
+      "feels_like": -3.62,
+      "pressure": 1000,
+      "humidity": 97,
+      "dew_point": 0.54,
+      "uvi": 0.32,
+      "clouds": 100,
+      "visibility": 8569,
+      "wind_speed": 5.15,
+      "wind_deg": 287,
+      "wind_gust": 9.46,
+      "weather": [
+        {
+          "id": 600,
+          "main": "Snow",
+          "description": "light snow",
+          "icon": "13d"
+        }
+      ],
+      "pop": 1,
+      "snow": {
+        "1h": 0.29
+      }
+    }
+  ],
+  "daily": [
+    {
+      "dt": 1740502800,
+      "sunrise": 1740484723,
+      "sunset": 1740524308,
+      "moonrise": 1740481140,
+      "moonset": 1740513960,
+      "moon_phase": 0.91,
+      "summary": "Expect a day of partly cloudy with rain",
+      "temp": {
+        "day": 1.81,
+        "min": 1.64,
+        "max": 3.37,
+        "night": 1.89,
+        "eve": 3.37,
+        "morn": 1.85
+      },
+      "feels_like": {
+        "day": -2.25,
+        "night": -1.86,
+        "eve": 0.77,
+        "morn": -0.38
+      },
+      "pressure": 1005,
+      "humidity": 99,
+      "dew_point": 1.39,
+      "wind_speed": 5.26,
+      "wind_deg": 237,
+      "wind_gust": 10.91,
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10d"
+        }
+      ],
+      "clouds": 100,
+      "pop": 0.2,
+      "rain": 0.87,
+      "uvi": 1.08
+    },
+    {
+      "dt": 1740589200,
+      "sunrise": 1740571024,
+      "sunset": 1740610787,
+      "moonrise": 1740569400,
+      "moonset": 1740605160,
+      "moon_phase": 0.95,
+      "summary": "There will be partly cloudy today",
+      "temp": {
+        "day": 1.42,
+        "min": -0.24,
+        "max": 1.64,
+        "night": 0.45,
+        "eve": 0.37,
+        "morn": 0.18
+      },
+      "feels_like": {
+        "day": -1.56,
+        "night": -3.48,
+        "eve": 0.37,
+        "morn": -2.3
+      },
+      "pressure": 1015,
+      "humidity": 92,
+      "dew_point": -0.08,
+      "wind_speed": 5.44,
+      "wind_deg": 312,
+      "wind_gust": 9.66,
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "overcast clouds",
+          "icon": "04d"
+        }
+      ],
+      "clouds": 93,
+      "pop": 0,
+      "uvi": 2.81
+    },
+    {
+      "dt": 1740675600,
+      "sunrise": 1740657324,
+      "sunset": 1740697265,
+      "moonrise": 1740657360,
+      "moonset": 1740696420,
+      "moon_phase": 0,
+      "summary": "Expect a day of partly cloudy with snow",
+      "temp": {
+        "day": 0.01,
+        "min": -0.36,
+        "max": 1.86,
+        "night": 1.86,
+        "eve": 0.88,
+        "morn": -0.07
+      },
+      "feels_like": {
+        "day": 0.01,
+        "night": -3.69,
+        "eve": -3.39,
+        "morn": -5.51
+      },
+      "pressure": 1001,
+      "humidity": 97,
+      "dew_point": -0.71,
+      "wind_speed": 7.43,
+      "wind_deg": 284,
+      "wind_gust": 12.46,
+      "weather": [
+        {
+          "id": 601,
+          "main": "Snow",
+          "description": "snow",
+          "icon": "13d"
+        }
+      ],
+      "clouds": 100,
+      "pop": 1,
+      "snow": 8.68,
+      "uvi": 1.13
+    },
+    {
+      "dt": 1740762000,
+      "sunrise": 1740743623,
+      "sunset": 1740783744,
+      "moonrise": 1740745080,
+      "moonset": 1740787620,
+      "moon_phase": 0.03,
+      "summary": "You can expect partly cloudy in the morning, with snow in the afternoon",
+      "temp": {
+        "day": -8.21,
+        "min": -11.13,
+        "max": -0.32,
+        "night": -4.64,
+        "eve": -6.81,
+        "morn": -9.75
+      },
+      "feels_like": {
+        "day": -14.25,
+        "night": -11.64,
+        "eve": -13.81,
+        "morn": -16.75
+      },
+      "pressure": 1010,
+      "humidity": 75,
+      "dew_point": -12.48,
+      "wind_speed": 11.19,
+      "wind_deg": 101,
+      "wind_gust": 17.35,
+      "weather": [
+        {
+          "id": 601,
+          "main": "Snow",
+          "description": "snow",
+          "icon": "13d"
+        }
+      ],
+      "clouds": 75,
+      "pop": 1,
+      "snow": 8.01,
+      "uvi": 2.53
+    },
+    {
+      "dt": 1740848400,
+      "sunrise": 1740829922,
+      "sunset": 1740870221,
+      "moonrise": 1740832800,
+      "moonset": 1740878760,
+      "moon_phase": 0.06,
+      "summary": "Expect a day of partly cloudy with snow",
+      "temp": {
+        "day": -9.22,
+        "min": -14.82,
+        "max": -5.73,
+        "night": -14.82,
+        "eve": -12,
+        "morn": -10.62
+      },
+      "feels_like": {
+        "day": -16.22,
+        "night": -21.82,
+        "eve": -19,
+        "morn": -17.62
+      },
+      "pressure": 1010,
+      "humidity": 79,
+      "dew_point": -13.14,
+      "wind_speed": 10.1,
+      "wind_deg": 73,
+      "wind_gust": 12.34,
+      "weather": [
+        {
+          "id": 601,
+          "main": "Snow",
+          "description": "snow",
+          "icon": "13d"
+        }
+      ],
+      "clouds": 100,
+      "pop": 1,
+      "snow": 7.79,
+      "uvi": 2.34
+    },
+    {
+      "dt": 1740934800,
+      "sunrise": 1740916220,
+      "sunset": 1740956699,
+      "moonrise": 1740920460,
+      "moonset": 1740970080,
+      "moon_phase": 0.1,
+      "summary": "Expect a day of partly cloudy with snow",
+      "temp": {
+        "day": -5.09,
+        "min": -16.07,
+        "max": -3.43,
+        "night": -10.59,
+        "eve": -7.52,
+        "morn": -16.07
+      },
+      "feels_like": {
+        "day": -11.14,
+        "night": -17.53,
+        "eve": -14.45,
+        "morn": -21.62
+      },
+      "pressure": 1023,
+      "humidity": 73,
+      "dew_point": -9.63,
+      "wind_speed": 7.11,
+      "wind_deg": 261,
+      "wind_gust": 9.2,
+      "weather": [
+        {
+          "id": 600,
+          "main": "Snow",
+          "description": "light snow",
+          "icon": "13d"
+        }
+      ],
+      "clouds": 65,
+      "pop": 1,
+      "snow": 0.72,
+      "uvi": 3
+    },
+    {
+      "dt": 1741021200,
+      "sunrise": 1741002517,
+      "sunset": 1741043176,
+      "moonrise": 1741008240,
+      "moonset": 1741061340,
+      "moon_phase": 0.14,
+      "summary": "Expect a day of partly cloudy with clear spells",
+      "temp": {
+        "day": -3.14,
+        "min": -11.94,
+        "max": -2.24,
+        "night": -7.58,
+        "eve": -6.46,
+        "morn": -10.65
+      },
+      "feels_like": {
+        "day": -8.06,
+        "night": -11.66,
+        "eve": -11.26,
+        "morn": -16.51
+      },
+      "pressure": 1025,
+      "humidity": 64,
+      "dew_point": -9.28,
+      "wind_speed": 4.05,
+      "wind_deg": 227,
+      "wind_gust": 5.76,
+      "weather": [
+        {
+          "id": 800,
+          "main": "Clear",
+          "description": "clear sky",
+          "icon": "01d"
+        }
+      ],
+      "clouds": 8,
+      "pop": 0,
+      "uvi": 3
+    },
+    {
+      "dt": 1741107600,
+      "sunrise": 1741088813,
+      "sunset": 1741129652,
+      "moonrise": 1741096320,
+      "moonset": 0,
+      "moon_phase": 0.18,
+      "summary": "Expect a day of partly cloudy with rain",
+      "temp": {
+        "day": 0.7,
+        "min": -7.39,
+        "max": 1.18,
+        "night": 1.18,
+        "eve": 1.18,
+        "morn": -5.6
+      },
+      "feels_like": {
+        "day": -4.12,
+        "night": -0.81,
+        "eve": -2.81,
+        "morn": -5.6
+      },
+      "pressure": 1014,
+      "humidity": 81,
+      "dew_point": -2.63,
+      "wind_speed": 5.15,
+      "wind_deg": 215,
+      "wind_gust": 12.29,
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "light rain",
+          "icon": "10d"
+        }
+      ],
+      "clouds": 100,
+      "pop": 0.2,
+      "rain": 0.18,
+      "uvi": 3
+    }
+  ]
+}


### PR DESCRIPTION
This pull request includes changes to the `WeatherForecast` conversion and its corresponding test case. The primary focus is on improving the calculation of cumulative snow data and adding a new test to verify the correct behavior of the conversion function.

Improvements to cumulative snow data calculation:

* [`service/openweather/src/main/java/org/openweathermap/api/model/Converter.kt`](diffhunk://#diff-6249cf3c48d159677885522300ce08d4003e6306b0b133faf89ac22047e34b3eR25): Modified the `toForecastData` method to use the `take` function for selecting the first 24 hours of data when calculating `dailyCumulativeSnow`.

Addition of new test case:

* [`service/openweather/src/test/java/org/openweathermap/api/WeatherForecastConverterTest.kt`](diffhunk://#diff-bc2e8d3ec1c520db4935845237d429e931168f89be02cc5181206e9abdb2d754R96-R111): Added a new test case to verify that light snow in Oshawa city further out does not show snow in the next 24 hours. This test checks various attributes such as latitude, longitude, and cumulative snow and rain data.