### PR TITLE
Add unit tests for Tomorrow.io service data models

### DIFF
--- a/service/tomorrowio/src/test/java/io/tomorrow/api/model/RealTimeWeatherResponseTest.kt
+++ b/service/tomorrowio/src/test/java/io/tomorrow/api/model/RealTimeWeatherResponseTest.kt
@@ -1,0 +1,64 @@
+package io.tomorrow.api.model
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.junit.Test
+
+class RealTimeWeatherResponseTest {
+
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
+    private fun loadJsonFromResources(fileName: String): String {
+        return RealTimeWeatherResponseTest::class.java.classLoader!!
+            .getResourceAsStream(fileName)!!
+            .bufferedReader()
+            .use { it.readText() }
+    }
+
+    @Test
+    fun `parses RealTimeWeatherResponse from JSON correctly`() {
+        val jsonString = loadJsonFromResources("sample_realtime_weather.json")
+        val adapter = moshi.adapter(RealTimeWeatherResponse::class.java)
+        val response = adapter.fromJson(jsonString)
+
+        assertThat(response).isNotNull()
+        response!! // Ensure response is not null for subsequent assertions
+
+        // Assertions for location
+        assertThat(response.location.latitude).isEqualTo(43.653480529785156)
+        assertThat(response.location.longitude).isEqualTo(-79.3839340209961)
+        // Note: 'name' and 'type' are not part of the Location data class in TomorrowIo.kt,
+        // so they won't be parsed into the object and cannot be asserted here.
+
+        // Assertions for data
+        assertThat(response.data.time).isEqualTo("2025-01-12T01:40:00Z")
+
+        // Assertions for weather values
+        val values = response.data.values
+        assertThat(values.cloudBase).isEqualTo(1.5)
+        assertThat(values.cloudCeiling).isEqualTo(2.5)
+        assertThat(values.cloudCover).isEqualTo(75.0)
+        assertThat(values.dewPoint).isEqualTo(-4.88)
+        assertThat(values.freezingRainIntensity).isEqualTo(0.0)
+        assertThat(values.hailProbability).isEqualTo(97.7)
+        assertThat(values.hailSize).isEqualTo(4.27)
+        assertThat(values.humidity).isEqualTo(88.0)
+        assertThat(values.precipitationProbability).isEqualTo(0)
+        assertThat(values.pressureSurfaceLevel).isEqualTo(999.33)
+        assertThat(values.rainIntensity).isEqualTo(0.0)
+        assertThat(values.sleetIntensity).isEqualTo(0.0)
+        assertThat(values.snowIntensity).isEqualTo(0.0)
+        assertThat(values.temperature).isEqualTo(-3.19)
+        assertThat(values.temperatureApparent).isEqualTo(-7.02)
+        assertThat(values.uvHealthConcern).isEqualTo(0)
+        assertThat(values.uvIndex).isEqualTo(0)
+        assertThat(values.visibility).isEqualTo(16.0)
+        assertThat(values.weatherCode).isEqualTo(1000)
+        assertThat(values.windDirection).isEqualTo(270.38)
+        assertThat(values.windGust).isEqualTo(6.5)
+        assertThat(values.windSpeed).isEqualTo(2.69)
+    }
+}

--- a/service/tomorrowio/src/test/java/io/tomorrow/api/model/TomorrowIoApiErrorResponseTest.kt
+++ b/service/tomorrowio/src/test/java/io/tomorrow/api/model/TomorrowIoApiErrorResponseTest.kt
@@ -1,0 +1,54 @@
+package io.tomorrow.api.model
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.junit.Test
+
+class TomorrowIoApiErrorResponseTest {
+
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
+    private fun loadJsonFromResources(fileName: String): String {
+        return TomorrowIoApiErrorResponseTest::class.java.classLoader!!
+            .getResourceAsStream(fileName)!!
+            .bufferedReader()
+            .use { it.readText() }
+    }
+
+    @Test
+    fun `parses TomorrowIoApiErrorResponse from JSON correctly`() {
+        val jsonString = loadJsonFromResources("sample_api_error.json")
+        val adapter = moshi.adapter(TomorrowIoApiErrorResponse::class.java)
+        val errorResponse = adapter.fromJson(jsonString)
+
+        assertThat(errorResponse).isNotNull()
+        errorResponse!! // Ensure response is not null
+
+        assertThat(errorResponse.code).isEqualTo(429001)
+        assertThat(errorResponse.type).isEqualTo("Too Many Calls")
+        assertThat(errorResponse.message).isEqualTo("The request limit for this resource has been reached for the current rate limit window. Wait and retry the operation, or examine your API request volume.")
+    }
+
+    @Test
+    fun `parses another TomorrowIoApiErrorResponse sample`() {
+        val jsonString = """
+        {
+          "code": 401001,
+          "type": "Invalid Auth",
+          "message": "The method requires authentication but it was not presented or is invalid."
+        }
+        """.trimIndent()
+        val adapter = moshi.adapter(TomorrowIoApiErrorResponse::class.java)
+        val errorResponse = adapter.fromJson(jsonString)
+
+        assertThat(errorResponse).isNotNull()
+        errorResponse!! // Ensure response is not null
+
+        assertThat(errorResponse.code).isEqualTo(401001)
+        assertThat(errorResponse.type).isEqualTo("Invalid Auth")
+        assertThat(errorResponse.message).isEqualTo("The method requires authentication but it was not presented or is invalid.")
+    }
+}

--- a/service/tomorrowio/src/test/resources/sample_api_error.json
+++ b/service/tomorrowio/src/test/resources/sample_api_error.json
@@ -1,0 +1,5 @@
+{
+  "code": 429001,
+  "type": "Too Many Calls",
+  "message": "The request limit for this resource has been reached for the current rate limit window. Wait and retry the operation, or examine your API request volume."
+}

--- a/service/tomorrowio/src/test/resources/sample_realtime_weather.json
+++ b/service/tomorrowio/src/test/resources/sample_realtime_weather.json
@@ -1,0 +1,35 @@
+{
+  "data": {
+    "time": "2025-01-12T01:40:00Z",
+    "values": {
+      "cloudBase": 1.5,
+      "cloudCeiling": 2.5,
+      "cloudCover": 75.0,
+      "dewPoint": -4.88,
+      "freezingRainIntensity": 0.0,
+      "hailProbability": 97.7,
+      "hailSize": 4.27,
+      "humidity": 88.0,
+      "precipitationProbability": 0,
+      "pressureSurfaceLevel": 999.33,
+      "rainIntensity": 0.0,
+      "sleetIntensity": 0.0,
+      "snowIntensity": 0.0,
+      "temperature": -3.19,
+      "temperatureApparent": -7.02,
+      "uvHealthConcern": 0,
+      "uvIndex": 0,
+      "visibility": 16.0,
+      "weatherCode": 1000,
+      "windDirection": 270.38,
+      "windGust": 6.5,
+      "windSpeed": 2.69
+    }
+  },
+  "location": {
+    "lat": 43.653480529785156,
+    "lon": -79.3839340209961,
+    "name": "Toronto, Golden Horseshoe, Ontario, Canada",
+    "type": "administrative"
+  }
+}


### PR DESCRIPTION
This commit introduces unit tests for parsing the following data models in the `service/tomorrowio` module:
- `RealTimeWeatherResponse`
- `TomorrowIoApiErrorResponse`

The tests verify that Moshi correctly parses sample JSON into these data classes, checking all relevant fields. Sample JSON files (`sample_realtime_weather.json` and `sample_api_error.json`) have been added to `src/test/resources`.

Note: Due to limitations in my current environment (missing Android SDK), I was unable to run these tests automatically after creating them. They will need to be executed in an environment with a properly configured Android SDK.