### PR TITLE
Add test notification button to settings screen

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/ui/settings/UserSettingsScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/settings/UserSettingsScreen.kt
@@ -244,9 +244,10 @@ fun UserSettingsScreen(
                 onClick = {
                     state.eventSink(UserSettingsScreen.Event.TestNotification)
                 },
-                modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(vertical = 8.dp),
+                modifier =
+                    Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(vertical = 8.dp),
             ) {
                 Text("Test Notification")
             }


### PR DESCRIPTION
## Overview
This PR adds a "Test Notification" button in the settings screen to allow users to preview how notifications will appear and verify notification permissions.

## Changes Made
- Added `TestNotification` event to `UserSettingsScreen`
- Implemented event handler in `UserSettingsPresenter` that triggers a test notification
- Added `ElevatedButton` in the UI between update frequency and service selection
- Test notification uses snow alert with sample data (25.0 vs 20.0 threshold for "Test City")
- Reuses existing `triggerNotification()` function from `Notification.kt`

## Benefits
- Users can verify notification permissions are working
- Builds confidence in app functionality  
- Helps users understand what alerts will look like
- Easy to debug notification delivery issues

## Testing
- Code follows Circuit UDF pattern
- No syntax errors detected by IDE
- Follows project's architectural patterns and coding standards

## Demo

https://github.com/user-attachments/assets/dc0b0086-f358-41e7-8b95-f10a14040b14



Fixes #477