### PR TITLE
[BUMP] Version bump to 2.11

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,9 +42,9 @@ android {
         applicationId = "dev.hossain.weatheralert"
         minSdk = 30
         targetSdk = 36
-        versionCode = 19
+        versionCode = 20
         // 🤓 FYI: Don't forget to update release notes.
-        versionName = "2.10"
+        versionName = "2.11"
 
         // Read bundled API key from local.properties
         val localProperties = project.rootProject.file("local.properties").takeIf { it.exists() }?.inputStream()?.use {


### PR DESCRIPTION
## Version Bump to 2.11

This PR bumps the version for the next release cycle:

- `versionCode`: 19 → 20
- `versionName`: "2.10" → "2.11"

### Changes
- Updated `app/build.gradle.kts` with new version numbers
- Release notes will be updated when v2.11 features are ready

Ready to merge to prepare for next development cycle.