### PR TITLE
UI: Add horizontal dividers to Credits screen

### DIFF
--- a/app/src/main/java/dev/hossain/weatheralert/ui/about/AppCreditsScreen.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/about/AppCreditsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -150,7 +151,7 @@ fun AppCreditsScreen(
             SimpleMapsLinkedText()
 
             // - - - - - - - - - - - - - - - - - - -
-            Spacer(modifier = Modifier.height(8.dp))
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp, horizontal = 32.dp))
 
             Image(
                 painter = painterResource(R.drawable.alien_monster_icon),
@@ -171,7 +172,7 @@ fun AppCreditsScreen(
             )
 
             // - - - - - - - - - - - - - - - - - - -
-            Spacer(modifier = Modifier.height(16.dp))
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp, horizontal = 32.dp))
 
             Image(
                 painter = painterResource(R.drawable.cloud_servers),


### PR DESCRIPTION
## Changes
Added horizontal dividers between sections in the AppCreditsScreen to improve visual separation and readability.

### Details
- Added `HorizontalDivider` component between each credit section:
  - Between "City Database" and "Icons" sections
  - Between "Icons" and "Weather Forecast API Services" sections
- Applied 32dp horizontal padding to dividers to align with screen content padding
- Imported `HorizontalDivider` from Material 3 components

### Visual Impact
The dividers provide clear visual separation between different credit categories, making it easier for users to distinguish between the city database provider, icon sources, and weather API services.

### Screenshot
_(Manual testing recommended to verify visual appearance)_