### PR TITLE
Add Git LFS support to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/git-lfs:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -4,6 +4,10 @@ set -e
 
 echo "🚀 Setting up Android development environment..."
 
+# Initialize Git LFS
+echo "📦 Initializing Git LFS..."
+git lfs install
+
 # Define Android SDK paths
 export ANDROID_HOME="/usr/local/lib/android/sdk"
 export ANDROID_SDK_ROOT="${ANDROID_HOME}"


### PR DESCRIPTION
## Changes
- Add `git-lfs` feature to `devcontainer.json`
- Initialize Git LFS in `post-create.sh` script

## Problem
Users were seeing warnings when using git commands:
```
This repository is configured for Git LFS but 'git-lfs' was not found on your path.
```

## Solution
- Added the official Git LFS dev container feature
- Added `git lfs install` to the post-create script to ensure Git LFS is initialized

## Testing
- Dev container will now include Git LFS pre-installed
- No more warnings about missing git-lfs binary
- Git operations with LFS-tracked files will work seamlessly

## Related
Fixes the recurring Git LFS warnings in the development environment.