### PR TITLE
Update agp gradle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,13 +84,9 @@ android {
             )
             signingConfig = signingConfigs.getByName("release")
 
-            firebaseCrashlytics {
-                // https://firebase.google.com/docs/crashlytics/get-deobfuscated-reports?platform=android
-                // https://developer.android.com/studio/debug/stacktraces
-                // https://developer.android.com/tools/retrace
-                // https://www.guardsquare.com/manual/tools/retrace
-                mappingFileUploadEnabled = true
-            }
+            // Note: firebaseCrashlytics { mappingFileUploadEnabled } removed — isMinifyEnabled=false
+            // means no mapping file is generated, so upload configuration is a no-op.
+            // See: https://firebase.google.com/docs/crashlytics/get-deobfuscated-reports?platform=android
         }
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     alias(libs.plugins.androidx.room)
     alias(libs.plugins.firebase.crashlytics)
     alias(libs.plugins.google.services)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.metro)
@@ -114,6 +113,12 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
+    }
+
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
@@ -131,13 +136,6 @@ android {
     }
 }
 
-
-kotlin {
-    // See https://kotlinlang.org/docs/gradle-compiler-options.html
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
-}
 
 
 // Kotlin Code Coverage - https://github.com/Kotlin/kotlinx-kover

--- a/data-model/build.gradle.kts
+++ b/data-model/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlinter)
     alias(libs.plugins.kotlinx.kover)
 }
@@ -34,11 +33,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-}
 
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,3 +45,12 @@ org.gradle.daemon=true
 # Disable unused build features
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.enableAppCompileTimeRClass=false
+android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -52,5 +52,5 @@ android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
 android.r8.optimizedResourceShrinking=false
-android.builtInKotlin=false
-android.newDsl=false
+
+android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ activityCompose = "1.13.0"
 # https://developer.android.com/jetpack/androidx/releases/compose-material3-adaptive
 adaptiveAndroid = "1.2.0"
 
-agp = "8.13.2"
+agp = "9.1.1"
 
 # Metro dependency injection framework
 # https://zacsweers.github.io/metro/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,11 +5,15 @@ activityCompose = "1.13.0"
 # https://developer.android.com/jetpack/androidx/releases/compose-material3-adaptive
 adaptiveAndroid = "1.2.0"
 
+# Android Gradle plugin
+# https://developer.android.com/studio/releases/gradle-plugin
+# https://developer.android.com/build/releases/about-agp
 agp = "9.1.1"
 
 # Metro dependency injection framework
 # https://zacsweers.github.io/metro/
-metro = "0.13.1"
+# https://github.com/ZacSweers/metro/releases
+metro = "1.0.0-RC2"
 
 # https://github.com/slackhq/circuit/releases
 circuit = "0.33.1"
@@ -25,7 +29,10 @@ dataStore = "1.2.1"
 # https://github.com/slackhq/EitherNet
 eithernet = "2.0.0"
 espressoCore = "3.7.0"
-firebaseBom = "34.11.0"
+
+# Firebase for Android
+# https://firebase.google.com/docs/android/learn-more
+firebaseBom = "34.12.0"
 
 # https://developer.android.com/develop/ui/compose/text/fonts
 googleFonts = "1.10.6"
@@ -49,10 +56,10 @@ kotlinter = "5.4.2"
 
 googleGmsServices = "4.4.4"
 
-crashlyticsPlugin = "3.0.6"
+crashlyticsPlugin = "3.0.7"
 
-kotlinxSerializationJson = "1.10.0"
-kotlinxSerializationProperties = "1.10.0"
+kotlinxSerializationJson = "1.11.0"
+kotlinxSerializationProperties = "1.11.0"
 
 # Kotlin Symbol Processing API
 # https://kotlinlang.org/docs/ksp-overview.html

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/service/openmeteo/build.gradle.kts
+++ b/service/openmeteo/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlinter)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.kotlinx.kover)
@@ -31,11 +30,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-}
 
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
     }
 }
 

--- a/service/openweather/build.gradle.kts
+++ b/service/openweather/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinter)
     alias(libs.plugins.kotlinx.kover)
@@ -31,11 +30,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-}
 
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
     }
 }
 

--- a/service/tomorrowio/build.gradle.kts
+++ b/service/tomorrowio/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinter)
     alias(libs.plugins.kotlinx.kover)
@@ -31,11 +30,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-}
 
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
     }
 }
 

--- a/service/weatherapi/build.gradle.kts
+++ b/service/weatherapi/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinter)
     alias(libs.plugins.kotlinx.kover)
@@ -31,11 +30,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-}
 
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
     }
 }
 


### PR DESCRIPTION
This pull request upgrades the build system and dependencies to newer versions, simplifies Kotlin configuration, and adds several Android build property tweaks for improved build performance and compatibility. The main changes include updating Gradle and the Android Gradle Plugin, consolidating Kotlin JVM target configuration, and adjusting plugin usage in module build scripts.

**Build system and dependency upgrades:**

* Upgraded Gradle to 9.4.1 and the Android Gradle Plugin (AGP) to 9.1.1 for improved build performance and compatibility. [[1]](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL8-R16)
* Updated key dependencies: Metro to 1.0.0-RC2, Firebase BOM to 34.12.0, Crashlytics plugin to 3.0.7, and kotlinx.serialization to 1.11.0. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL8-R16) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL28-R35) [[3]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL52-R62)

**Kotlin configuration simplification:**

* Removed the `kotlin-android` plugin from module build scripts where it was redundant, and consolidated Kotlin JVM target configuration directly under the `android {}` block for all modules. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L9) [[2]](diffhunk://#diff-6cbe95e8e8ffa729eb7ad380b34238fbbccb163a3e54a646c7fdbe41a80372c3L3) [[3]](diffhunk://#diff-8e5f7e936184a0348ee6b6257c93f1e69e3b132d9aca49f03e4252e120aff90cL3) [[4]](diffhunk://#diff-aec873f6604ec7db666510564656a9d6e02619383e0703706d346774e8d16c78L3) [[5]](diffhunk://#diff-aa02cf4f15ce20eed6ea9e71cc74f7ec480143637d3c47f794026e5cb20f9c01L3) [[6]](diffhunk://#diff-e996a2a88705731772f93d63e06a394f5914a89a228495853b2d6e365f9521a3L3) [[7]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R112-R117) [[8]](diffhunk://#diff-6cbe95e8e8ffa729eb7ad380b34238fbbccb163a3e54a646c7fdbe41a80372c3L37-R42) [[9]](diffhunk://#diff-8e5f7e936184a0348ee6b6257c93f1e69e3b132d9aca49f03e4252e120aff90cL34-R39) [[10]](diffhunk://#diff-aec873f6604ec7db666510564656a9d6e02619383e0703706d346774e8d16c78L34-R39) [[11]](diffhunk://#diff-aa02cf4f15ce20eed6ea9e71cc74f7ec480143637d3c47f794026e5cb20f9c01L34-R39) [[12]](diffhunk://#diff-e996a2a88705731772f93d63e06a394f5914a89a228495853b2d6e365f9521a3L34-R39) [[13]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L135-L141)

**Android build property adjustments:**

* Added and updated several properties in `gradle.properties` to tweak build features, dependency resolution, and resource shrinking for improved build times and compatibility with the upgraded toolchain.

**Crashlytics configuration cleanup:**

* Removed redundant Crashlytics mapping file upload configuration in `build.gradle.kts` since mapping files are not generated when ProGuard/R8 minification is disabled.

These changes collectively modernize the build setup, reduce redundancy, and ensure compatibility with the latest Android and Kotlin tooling.