### PR TITLE
Upgrade androidx.fragment:fragment dependency to 1.8.9

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -175,6 +175,7 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.adaptive.android)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.fragment)
     implementation(libs.androidx.datastore.core)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/test/java/dev/hossain/weatheralert/util/DateFormatterSnoozeTest.kt
+++ b/app/src/test/java/dev/hossain/weatheralert/util/DateFormatterSnoozeTest.kt
@@ -40,8 +40,19 @@ class DateFormatterSnoozeTest {
 
         assertThat(result).isNotNull()
         assertThat(result).startsWith("Snoozed until")
-        // Should not contain "tomorrow" since it is later today
-        assertThat(result).doesNotContain("tomorrow")
+
+        val futureDateTime = java.time.LocalDateTime.ofInstant(
+            java.time.Instant.ofEpochMilli(futureTimestamp),
+            java.time.ZoneId.systemDefault()
+        )
+        val now = java.time.LocalDateTime.now(java.time.ZoneId.systemDefault())
+        val isTomorrow = futureDateTime.toLocalDate() == now.toLocalDate().plusDays(1)
+
+        if (isTomorrow) {
+            assertThat(result).contains("tomorrow")
+        } else {
+            assertThat(result).doesNotContain("tomorrow")
+        }
     }
 
     @Test

--- a/app/src/test/java/dev/hossain/weatheralert/util/DateFormatterSnoozeTest.kt
+++ b/app/src/test/java/dev/hossain/weatheralert/util/DateFormatterSnoozeTest.kt
@@ -41,10 +41,11 @@ class DateFormatterSnoozeTest {
         assertThat(result).isNotNull()
         assertThat(result).startsWith("Snoozed until")
 
-        val futureDateTime = java.time.LocalDateTime.ofInstant(
-            java.time.Instant.ofEpochMilli(futureTimestamp),
-            java.time.ZoneId.systemDefault()
-        )
+        val futureDateTime =
+            java.time.LocalDateTime.ofInstant(
+                java.time.Instant.ofEpochMilli(futureTimestamp),
+                java.time.ZoneId.systemDefault(),
+            )
         val now = java.time.LocalDateTime.now(java.time.ZoneId.systemDefault())
         val isTomorrow = futureDateTime.toLocalDate() == now.toLocalDate().plusDays(1)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ composeBom = "2026.04.01"
 composeMaterial3 = "1.4.0"
 coreKtx = "1.18.0"
 coroutinesTest = "1.10.2"
+fragment = "1.8.9"
 
 dataStore = "1.2.1"
 
@@ -111,6 +112,7 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-junit-ktx = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "junitKtx" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-fragment = { group = "androidx.fragment", name = "fragment", version.ref = "fragment" }
 
 # Material Design 3 in Compose
 # https://developer.android.com/develop/ui/compose/designsystems/material3


### PR DESCRIPTION
Resolves the Google Play Console SDK alert regarding the outdated fragment transitive dependency by explicitly implementing version 1.8.9. Also includes a fix for the flaky DateFormatterSnoozeTest.