### PR TITLE
Target Android 17 (API 37)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,12 +35,12 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace = "dev.hossain.weatheralert"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "dev.hossain.weatheralert"
         minSdk = 30
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 25
         // 🤓 FYI: Don't forget to update release notes.
         versionName = "2.16"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.App"
-        tools:targetApi="36"
+        tools:targetApi="37"
         android:enableOnBackInvokedCallback="true"
         tools:replace="android:appComponentFactory">
         <activity

--- a/app/src/test/java/dev/hossain/weatheralert/util/DateFormatterSnoozeTest.kt
+++ b/app/src/test/java/dev/hossain/weatheralert/util/DateFormatterSnoozeTest.kt
@@ -40,8 +40,20 @@ class DateFormatterSnoozeTest {
 
         assertThat(result).isNotNull()
         assertThat(result).startsWith("Snoozed until")
-        // Should not contain "tomorrow" since it is later today
-        assertThat(result).doesNotContain("tomorrow")
+
+        val futureDateTime =
+            java.time.LocalDateTime.ofInstant(
+                java.time.Instant.ofEpochMilli(futureTimestamp),
+                java.time.ZoneId.systemDefault(),
+            )
+        val now = java.time.LocalDateTime.now(java.time.ZoneId.systemDefault())
+        val isTomorrow = futureDateTime.toLocalDate() == now.toLocalDate().plusDays(1)
+
+        if (isTomorrow) {
+            assertThat(result).contains("tomorrow")
+        } else {
+            assertThat(result).doesNotContain("tomorrow")
+        }
     }
 
     @Test

--- a/data-model/build.gradle.kts
+++ b/data-model/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "dev.hossain.weatheralert.datamodel"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ adaptiveAndroid = "1.2.0"
 # Android Gradle plugin
 # https://developer.android.com/studio/releases/gradle-plugin
 # https://developer.android.com/build/releases/about-agp
-agp = "9.2.0"
+agp = "9.2.1"
 
 # Metro dependency injection framework
 # https://zacsweers.github.io/metro/

--- a/service/openmeteo/build.gradle.kts
+++ b/service/openmeteo/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.openmeteo.api"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30

--- a/service/openweather/build.gradle.kts
+++ b/service/openweather/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "org.openweathermap.api"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30

--- a/service/tomorrowio/build.gradle.kts
+++ b/service/tomorrowio/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "io.tomorrow.api"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30

--- a/service/weatherapi/build.gradle.kts
+++ b/service/weatherapi/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.weatherapi.api"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 30


### PR DESCRIPTION
Upgrades compileSdk and targetSdk versions to API level 37 (Android 17) across all Gradle modules. Also sets targetApi to 37 in AndroidManifest.xml and fixes the flaky DateFormatterSnoozeTest.