### PR TITLE
Release v2.17

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,9 +41,9 @@ android {
         applicationId = "dev.hossain.weatheralert"
         minSdk = 30
         targetSdk = 37
-        versionCode = 25
+        versionCode = 26
         // 🤓 FYI: Don't forget to update release notes.
-        versionName = "2.16"
+        versionName = "2.17"
 
         // Read bundled API key from local.properties
         val localProperties = project.rootProject.file("local.properties").takeIf { it.exists() }?.inputStream()?.use {

--- a/resources/google-play/release-notes.md
+++ b/resources/google-play/release-notes.md
@@ -13,10 +13,17 @@
 ## Weather Alert v2.X
 
 ### What's new
-* Updated Kotlin to 2.3.21 (latest bug-fix release)
-* Updated KSP to 2.3.7 (targets Kotlin 2.3)
-* Updated Android Gradle Plugin (AGP) to 9.2.0
-* Updated Compose BOM to 2026.04.01 (Compose UI 1.11.0)
+* Update libraries and dependencies to latest available versions
+* Minor bug fixes and stability improvements
+
+## Weather Alert v2.17
+
+### What's new
+* Updated app to target Android 17 (API Level 37).
+* Added adaptive edge-to-edge support across all screens with proper status/navigation bar and IME insets.
+* Resolved Google Play Console outdated SDK warning by upgrading the fragment dependency to v1.8.9.
+* Upgraded core dependencies (Compose BOM to 2026.06.01, Core-KTX to 1.19.0, Lifecycle to 2.11.0, KSP to 2.3.9, Circuit to 0.34.0, Metro to 1.3.0).
+* Fixed a bug where onboarding completion state was not properly saved due to coroutine scope cancellation during navigation.
 
 ## Weather Alert v2.16
 


### PR DESCRIPTION
Prepares the Weather Alert app for the v2.17 release. Bumps the version code to 26 and version name to 2.17, adds the AGENTS.md symlink in the project root, and updates Google Play release notes with details of Android 17 targeting, edge-to-edge support, fragment dependency upgrade, library updates, and onboarding persistence fixes.