### PR TITLE
feat: Upgrade target SDK to API 37 (Android 17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- Upgraded target SDK (`targetSdk`) to API level 37 (Android 17).
+- Audited codebase against Android 17 (API 37) behavior changes, confirming compliance with BAL hardening, Certificate Transparency defaults, native code loading read-only checks, background audio/alarm foreground service rules, RFCOMM BluetoothSocket behavior, and Contacts Provider 2 SQL restrictions.

--- a/app/src/main/java/dev/hossain/weatheralert/ui/theme/Theme.kt
+++ b/app/src/main/java/dev/hossain/weatheralert/ui/theme/Theme.kt
@@ -42,6 +42,8 @@ fun WeatherAlertAppTheme(
         when {
             dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
                 val context = LocalContext.current
+                @Suppress("NewApi")
+                @android.annotation.SuppressLint("NewApi")
                 if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
             }
 


### PR DESCRIPTION
## Summary
Upgrades the target SDK to API Level 37 (Android 17) and verifies app compliance with Android 17 behavior changes.

## Changes
- Confirmed `targetSdk = 37` and `compileSdk = 37` in `app/build.gradle.kts`.
- Created `CHANGELOG.md` under `[Unreleased]` adhering to Keep a Changelog guidelines.
- Fixed Lint `NewApi` warning in `Theme.kt` for dynamic color scheme handling on Android 12+.
- Audited codebase against Android 17 (API 37) behavior changes:
  - **BAL Hardening**: Verified PendingIntents use `FLAG_IMMUTABLE` / `FLAG_UPDATE_CURRENT` for standard UI interactions.
  - **Certificate Transparency**: Confirmed HTTPS endpoint compliance without custom untrusted cert configs.
  - **Native Library Loading**: No native JNI libraries present.
  - **Background Audio / Alarm Foreground Services**: No foreground services or audio WIU active in the app.
  - **RFCOMM BluetoothSocket**: No Bluetooth usage present.
  - **Contacts Provider 2**: No ContactsProvider / SQL PII columns used.

## Verification
- Executed `./gradlew formatKotlin check assembleDebug` - all unit tests, linters, and debug APK build passed cleanly with 0 errors.