### PR TITLE
release/v2.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.18.0] - 2026-07-25
+## [2.19.0] - 2026-07-25
+
+### Changed
+- Maintenance release with version bump (`versionCode = 28`, `versionName = "2.19"`).
+
 
 ### Changed
 - Upgraded target SDK (`targetSdk`) to API level 37 (Android 17).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,9 +41,9 @@ android {
         applicationId = "dev.hossain.weatheralert"
         minSdk = 30
         targetSdk = 37
-        versionCode = 27
+        versionCode = 28
         // 🤓 FYI: Don't forget to update release notes.
-        versionName = "2.18"
+        versionName = "2.19"
 
         // Read bundled API key from local.properties
         val localProperties = project.rootProject.file("local.properties").takeIf { it.exists() }?.inputStream()?.use {

--- a/resources/google-play/release-notes.md
+++ b/resources/google-play/release-notes.md
@@ -16,6 +16,12 @@
 * Update libraries and dependencies to latest available versions
 * Minor bug fixes and stability improvements
 
+## Weather Alert v2.19
+
+### What's new
+* Update libraries and dependencies to latest available versions
+* Minor bug fixes and stability improvements
+
 ## Weather Alert v2.18
 
 ### What's new


### PR DESCRIPTION
## Release v2.19 (versionCode 28)

### Changes & Highlights
* Maintenance release bumping `versionCode` to 28 and `versionName` to 2.19.
* Update libraries and dependencies to latest available versions.
* Minor bug fixes and stability improvements.

### Verification
- Executed `./gradlew formatKotlin check assembleRelease` - all 679 tasks passed cleanly.